### PR TITLE
Bug: Help flag is no longer an  error.

### DIFF
--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -95,6 +95,7 @@ ysh() {
     ;;
     -h|--help)
         YSH_usage
+        exit 0
     ;;
     -f|--file)
         YSH_RAW_STRING="$(YSH_parse "${2}")"

--- a/test/test.sh
+++ b/test/test.sh
@@ -182,4 +182,10 @@ testSubSupportsEscapedQueries() {
     assertEquals 2 $(wc -l <<< "$result")
 }
 
+# From Issue https://github.com/azohra/yaml.sh/issues/13
+testHelpFlagShouldNotBeAnError() {
+    result=$(ysh -h)
+    assertEquals 0 $?
+}
+
 . ./test/shunit2

--- a/ysh
+++ b/ysh
@@ -95,6 +95,7 @@ ysh() {
     ;;
     -h|--help)
         YSH_usage
+        exit 0
     ;;
     -f|--file)
         YSH_RAW_STRING="$(YSH_parse "${2}")"
@@ -153,7 +154,7 @@ ysh() {
             exit 1
         ;;
         *)
-            echo "Unknown Usage!" > /dev/stdout
+            echo "Error: invalid use" > /dev/stdout
             exit 1
         ;;
         esac


### PR DESCRIPTION
## Motivation

Previously, passing the `-h` flag would result in an error and asking
the user to use the `-h` flag incorrectly.

## Architecture

`-h` will now exit the script early with the proper error code.

## Other Changes

None.

## References

- Closes #13