### PR TITLE
Add yq-style expression streams for v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to YAML.sh are documented here.
 
+## [1.1.0] - 2026-08-01
+
+Version 1.1 moves beyond exact paths with a read-only expression engine modeled on the highest-value parts of yq.
+
+### Added
+
+- Sequence and mapping iteration with `[]`, including chained forms such as `.services[].name`.
+- Pipe expressions that pass streams of node references between operations.
+- `select(...)` filters with numeric and string comparisons using `==`, `!=`, `>`, `>=`, `<`, and `<=`.
+- Boolean `and`, `or`, and `not` operations using YAML null/false truthiness.
+- The `//` alternative operator for defaults when a result is null, false, or absent.
+- `length`, `keys`, `has(...)`, `kind`, and yq-compatible `type` filters.
+- Multi-result output with one value or compact JSON document per line.
+- A focused expression fixture and ten new behavioral test groups, bringing the suite to 47 tests.
+
+### Changed
+
+- Missing mapping keys and out-of-range indexes now produce null, matching yq traversal semantics and enabling defaults.
+- Queries may begin with a filter such as `length`; a leading `.` is no longer required.
+- The evaluator retains node references, source metadata, aliases, and merge resolution throughout pipelines.
+
+### Known boundaries
+
+- Version 1.1 expressions are read-only. Assignment, deletion, construction, arithmetic, variables, recursive descent, optional traversal, and in-place updates remain future work.
+- YAML output and presentation-preserving edits require an emitter and are not part of this release.
+
 ## [1.0.0] - 2026-08-01
 
 Version 1 is a ground-up, intentionally breaking rebuild around a real YAML node graph and a yq-style command line.
@@ -87,6 +113,7 @@ Version 1 is a ground-up, intentionally breaking rebuild around a real YAML node
 
 - Report missing files and make the help flag exit successfully.
 
+[1.1.0]: https://github.com/azohra/yaml.sh/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/azohra/yaml.sh/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/azohra/yaml.sh/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/azohra/yaml.sh/compare/v0.2.1...v0.3.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v1.0.0" src="https://img.shields.io/badge/release-v1.0.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
+  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v1.1.0" src="https://img.shields.io/badge/release-v1.1.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
   <a href="https://github.com/azohra/yaml.sh/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/azohra/yaml.sh/ci.yml?style=for-the-badge&label=tests&labelColor=101410"></a>
   <img alt="POSIX shell plus AWK" src="https://img.shields.io/badge/runtime-sh_+_awk-f5f1e8?style=for-the-badge&labelColor=101410">
 </p>
@@ -31,6 +31,10 @@ $ ysh '.services[0].port' config.yml
 
 $ ysh -o=json '.services[0]' config.yml
 {"name":"api","enabled":true,"port":8080}
+
+$ ysh '.services[] | select(.enabled) | .name' config.yml
+api
+web
 ```
 
 ## The tiny idea
@@ -40,7 +44,7 @@ Sometimes `yq` is exactly the right answer. Sometimes you are writing the script
 YAML.sh lives in that second moment. Version 1 stopped pretending YAML was flattened text and built a real node graph instead:
 
 ```text
-YAML stream → node graph → aliases + merges → query → value / JSON / metadata
+YAML stream → node graph → aliases + merges → expression stream → values
 ```
 
 Mappings stay mappings. Empty sequences survive. Aliases retain identity. Keys containing dots no longer turn into existential crises.
@@ -48,7 +52,7 @@ Mappings stay mappings. Empty sequences survive. Aliases retain identity. Keys c
 ## Install one file
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.0.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -91,6 +95,19 @@ ysh '.services[0]' config.yml
 # {"name":"api","enabled":true}
 ```
 
+Then let v1.1 stream and filter real nodes:
+
+```sh
+ysh '.services[] | select(.enabled) | .name' config.yml
+# api
+
+ysh '.services | length' config.yml
+# 1
+
+ysh '.missing // "fallback"' config.yml
+# fallback
+```
+
 Pipe YAML in naturally:
 
 ```sh
@@ -111,12 +128,12 @@ ysh '.metadata["build[number]"]' config.yml
 | --- | --- |
 | Flattened `path="value"` records | Mapping, sequence, scalar, and alias nodes |
 | Bash | Portable `/bin/sh` |
-| Chainable query flags | One yq-style path |
+| Chainable query flags | One yq-style expression stream |
 | Collection identity lost | Empty `{}` and `[]` preserved |
 | Partial merge handling | Alias lists, flow mappings, and block merge sequences |
 | Parser internals hidden | `--ast` and `--events` on tap |
 
-The CLI break is intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
+Version 1.1 adds `[]`, pipes, `select`, comparisons, booleans, defaults, and collection helpers without changing the node graph. The original v1 CLI break remains intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
 
 ## Open the hood
 
@@ -170,7 +187,7 @@ That contract is the promise: supported syntax gets a test; neighboring unsuppor
 make all
 ```
 
-That rebuilds the standalone `ysh`, runs ShellCheck, and executes 37 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
+That rebuilds the standalone `ysh`, runs ShellCheck, and executes 47 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
 
 The constraint is the fun part. Come make AWK do something unreasonable.
 

--- a/_static/_www/docs/README.md
+++ b/_static/_www/docs/README.md
@@ -2,7 +2,7 @@
 
 YAML.sh is a yq-like query tool delivered as one portable shell script. It runs with the system `/bin/sh` and AWK, making it useful in bootstrap scripts, minimal containers, CI jobs, old machines, and every awkward environment where installing a language runtime feels absurd.
 
-> Version 1 is a ground-up architecture change: YAML is parsed into a node graph, references are resolved, and only then does the query engine select a result.
+> Version 1 is a ground-up architecture change: YAML is parsed into a node graph, references are resolved, and only then does the expression engine stream results.
 
 ```sh
 ysh '.server.host' config.yml
@@ -10,13 +10,17 @@ ysh '.server.host' config.yml
 
 ysh -o=json '.services[0]' config.yml
 # {"name":"api","enabled":true}
+
+ysh '.services[] | select(.enabled) | .name' config.yml
+# api
+# web
 ```
 
 ## Why it exists
 
 Sometimes `yq` is exactly the right answer. Sometimes you are writing the script that would install `yq`.
 
-YAML.sh aims for the useful middle: a familiar path-based interface, serious handling of common YAML structures, one auditable file, and no additional packages. It does not pretend that YAML is simple or claim complete specification compliance.
+YAML.sh aims for the useful middle: familiar yq-style paths, streams and filters; serious handling of common YAML structures; one auditable file; and no additional packages. It does not pretend that YAML is simple or claim complete specification compliance.
 
 ## What changed in v1
 
@@ -28,6 +32,8 @@ YAML.sh aims for the useful middle: a familiar path-based interface, serious han
 | Collection identity lost | Empty mappings and sequences preserved |
 | Tag syntax mostly discarded | Expanded tags attached to nodes |
 | Inline merge subset | Alias lists, flow mappings, and block merge sequences |
+
+Version 1.1 adds iteration, pipes, selection, comparisons, booleans, defaults, and collection helpers above that graph.
 
 ## Pick a path
 

--- a/_static/_www/docs/development.md
+++ b/_static/_www/docs/development.md
@@ -15,6 +15,7 @@ src/ysh.sh              POSIX shell CLI
 src/ysh.awk             YAML engine
 test/test.sh            behavioral suite
 test/advanced.yml       v1 conformance fixture
+test/expressions.yml    v1.1 expression fixture
 _static/_www            unified Cloudflare Pages site
 _static/_www/docs       documentation
 _static/_www/install    installer
@@ -31,6 +32,10 @@ For every supported feature:
 5. Update the support contract.
 
 The objective is not a vague percentage of YAML. It is an expanding set of behaviors users can rely on.
+
+## Add expression behavior
+
+Expression operators must preserve node references unless they intentionally compute a new value. Add tests for precedence, empty streams, null traversal, scalar and collection inputs, multi-result output, and parity with the equivalent yq expression where one exists.
 
 ## Portability
 

--- a/_static/_www/docs/getting-started.md
+++ b/_static/_www/docs/getting-started.md
@@ -5,7 +5,7 @@ YAML.sh ships as one executable text file. The released file contains both the p
 ## Install the pinned release
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.0.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -63,6 +63,20 @@ ysh '.services[0]' config.yml
 # {"name":"api","enabled":true}
 ```
 
+Stream and filter nodes:
+
+```sh
+ysh '.services[] | select(.enabled) | .name' config.yml
+# api
+```
+
+Use a default when a path is missing, null, or false:
+
+```sh
+ysh '.release.channel // "stable"' config.yml
+# stable
+```
+
 ## Standard input
 
 Omit the file to read YAML from standard input:
@@ -79,6 +93,6 @@ generate-config | ysh '.release.version' -
 
 ## Next steps
 
-- [Query quoted and punctuated keys](queries.md)
+- [Learn paths, streams, filters, and defaults](queries.md)
 - [Choose JSON, type, tag, or line output](output.md)
 - [Read the YAML support contract](supported_yml.md)

--- a/_static/_www/docs/index.html
+++ b/_static/_www/docs/index.html
@@ -11,7 +11,7 @@
   <link rel="canonical" href="https://yaml.azohra.com/docs/">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-  <link rel="stylesheet" href="theme.css?v=1.0.0">
+  <link rel="stylesheet" href="theme.css?v=1.1.0">
   <title>YAML.sh v1 docs</title>
 </head>
 <body>

--- a/_static/_www/docs/internals.md
+++ b/_static/_www/docs/internals.md
@@ -11,14 +11,16 @@ YAML node graph
     ↓
 alias + merge resolver
     ↓
-query evaluator
+expression parser
+    ↓
+node-stream evaluator
     ↓
 raw / JSON / type / tag / line / AST / events
 ```
 
 ## The shell layer
 
-The `/bin/sh` launcher handles arguments, input selection, document selection, and output mode. It passes the YAML stream and query to the embedded AWK program.
+The `/bin/sh` launcher handles arguments, input selection, document selection, and output mode. It passes the YAML stream and expression to the embedded AWK program.
 
 The development sources remain separate:
 
@@ -48,6 +50,12 @@ This representation makes empty collections possible and removes ambiguity betwe
 ## Merge resolution
 
 Merge entries remain marked edges in the graph. Lookup checks explicit entries first, then merge sources in declaration order. A collection pass produces the effective mapping keys for JSON output while preserving the same precedence.
+
+## Expression streams
+
+The v1.1 expression parser builds a small operator tree with explicit precedence for pipes, alternatives, booleans, and comparisons. Evaluation passes numbered streams of node references between operators. `[]` can expand one collection into many references; `select` tests each reference while returning the original node when its predicate succeeds.
+
+Because streams contain node IDs rather than copied values, type, tag, source line, alias identity, parentage, and merge behavior survive a pipeline. Computed booleans, strings, numbers, and key lists are represented as temporary graph nodes and use the same output path as parsed YAML.
 
 ## Diagnostics
 

--- a/_static/_www/docs/output.md
+++ b/_static/_www/docs/output.md
@@ -18,6 +18,14 @@ ysh '.server.ports' config.yml
 # [8080,8443]
 ```
 
+Expressions may return more than one node. Each scalar or compact JSON collection is written on its own line:
+
+```sh
+ysh '.services[] | select(.enabled) | .name' config.yml
+# api
+# web
+```
+
 ## JSON
 
 Use `--json`, `-o=json`, or `--output-format=json`:
@@ -61,6 +69,8 @@ ysh --line '.server.host' config.yml
 ```
 
 For an alias selection, the reported line is the alias occurrence. Type, tag, and value output resolve through the alias target.
+
+Computed expression values such as comparison results, `length`, `keys`, `kind`, and literals have source line zero because they do not occur in the YAML stream.
 
 ## AST
 

--- a/_static/_www/docs/queries.md
+++ b/_static/_www/docs/queries.md
@@ -1,73 +1,109 @@
 # Queries
 
-Version 1 uses one deliberately small, yq-shaped path language. Queries select a node from the parsed document rather than filtering flattened text.
+Version 1.1 evaluates a focused, read-only yq-style expression language over streams of node references. Paths still select exact nodes; iteration and pipes let one input become many results without flattening the YAML graph.
 
-## Root
+## Paths
 
-`.` selects the document root:
+`.` selects the document root. Mapping keys and zero-based sequence indexes compose naturally:
 
 ```sh
 ysh '.' config.yml
-```
-
-Root mappings and sequences are emitted as JSON by default. A root scalar is printed as text.
-
-## Mapping keys
-
-Append a bare key after `.`:
-
-```sh
-ysh '.server' config.yml
 ysh '.server.host' config.yml
-ysh '.server.tls.enabled' config.yml
-```
-
-Bare keys continue until the next `.` or `[`. For keys containing query punctuation, use bracket notation.
-
-## Sequence indexes
-
-Indexes are zero-based:
-
-```sh
-ysh '.ports[0]' config.yml
 ysh '.services[2].name' config.yml
+ysh '.["key.with.dots"]' config.yml
 ```
 
-An out-of-range index is an error rather than an empty result.
+Quoted bracket keys are required when query punctuation belongs to the key.
 
-## Quoted keys
-
-Bracket notation makes the key boundary explicit:
+Missing keys and out-of-range indexes produce null, matching yq traversal semantics:
 
 ```sh
-ysh '.["key.with.dots"]' config.yml
-ysh '.metadata["build[number]"]' config.yml
-ysh '.["a key with spaces"]' config.yml
+ysh --json '.missing' config.yml
+# null
 ```
 
-This is possible because v1 retains mapping identity. The old flattened representation could not distinguish a literal dot in a key from a query separator.
+## Iterate
+
+Empty brackets stream every sequence item or mapping value:
+
+```sh
+ysh '.services[].name' config.yml
+ysh '.metadata[]' config.yml
+```
+
+Each result retains its node identity, type, tag, source line, parent, aliases, and resolved merge behavior.
+
+## Pipe
+
+The pipe passes every result on its left into the expression on its right:
+
+```sh
+ysh '.services[] | .name' config.yml
+```
+
+Streams print one scalar or compact JSON collection per line.
+
+## Select
+
+`select(EXPRESSION)` keeps the current node when its predicate is truthy:
+
+```sh
+ysh '.services[] | select(.enabled) | .name' config.yml
+ysh '.services[] | select(.port >= 8000) | .name' config.yml
+```
+
+Null and false are falsey. Every other scalar and collection is truthy.
+
+## Comparisons and booleans
+
+Version 1.1 supports:
+
+- Equality: `==` and `!=`.
+- Ordering: `>`, `>=`, `<`, and `<=` for two numbers or two strings.
+- Boolean composition: `and`, `or`, and the `not` filter.
+
+```sh
+ysh '.services[] | select(.enabled and .tier == "backend") | .name' config.yml
+ysh '.services[] | .enabled | not' config.yml
+```
+
+Numeric comparisons normalize integers and finite floats. Like yq, equality comparisons operate on scalar values rather than treating whole collections as identical values.
+
+## Defaults
+
+The alternative operator `//` returns its right side when the left side is absent, null, or false:
+
+```sh
+ysh '.release.channel // "stable"' config.yml
+```
+
+## Collection helpers
+
+```sh
+ysh '.services | length' config.yml
+ysh '.metadata | keys' config.yml
+ysh '.metadata | has("owner")' config.yml
+ysh '.services | has(2)' config.yml
+```
+
+- `length` counts mapping entries, sequence items, or scalar characters; null has length zero.
+- `keys` returns mapping keys or sequence indexes.
+- `has(KEY)` checks a mapping key or sequence index.
+- `kind` returns `map`, `seq`, or `scalar`.
+- `type` returns a yq-style tag such as `!!map`, `!!seq`, `!!str`, or `!!int`.
+
+Filters can begin an expression when they operate on the root:
+
+```sh
+ysh 'length' config.yml
+```
 
 ## Merged and aliased nodes
 
-Queries follow aliases and mapping merge sources automatically:
+Expressions follow aliases and mapping merge sources automatically. Explicit entries override merged entries; in a merge sequence, the first source containing a key wins.
 
-```yaml
-defaults: &defaults
-  retries: 3
-production:
-  <<: *defaults
-  endpoint: api.example.com
-```
+## Current expression boundary
 
-```sh
-ysh '.production.retries' config.yml
-# 3
-```
+Version 1.1 is deliberately read-only. It does not yet implement recursive descent, optional traversal, arithmetic, string interpolation, variables, construction, assignment, deletion, YAML serialization, or in-place editing.
 
-Explicit mapping entries override merged entries. In a merge sequence, the first source containing a key wins.
-
-## Current query boundary
-
-Version 1 focuses on deterministic node selection. It does not yet implement pipes, wildcards, recursive descent, predicates, arithmetic, assignment, or in-place editing.
-
-Those are query-language features—not parser shortcuts—and can now be added without changing the YAML graph underneath.
+Those features require a writable reference evaluator and a YAML emitter. They can now be added above the same node-stream architecture without replacing the parser.

--- a/_static/_www/docs/supported_yml.md
+++ b/_static/_www/docs/supported_yml.md
@@ -67,12 +67,12 @@ YAML version directives are validated but do not switch between complete YAML 1.
 - Flow collections must fit on one line.
 - The complete YAML Unicode escape repertoire and every block-folding edge case are not implemented.
 - Full YAML 1.1/1.2 schema resolution and application-specific construction are not implemented.
-- The query language does not yet provide pipes, wildcards, filters, assignments, or in-place updates.
+- The expression language is read-only. It does not yet provide recursive descent, optional traversal, arithmetic, variables, construction, assignments, deletion, YAML serialization, or in-place updates.
 
 YAML.sh does not evaluate YAML as shell code, but it is not a complete specification validator. Use a maintained full YAML library when exact conformance for arbitrary or hostile input is a hard requirement.
 
 ## Conformance fixture
 
-The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. Rejection tests cover every limitation that could otherwise be misread as supported syntax.
+The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. The expression fixture covers node streams, iteration, pipes, filters, comparisons, booleans, defaults, and collection helpers. Rejection tests cover every limitation that could otherwise be misread as supported syntax.
 
 See [`test/advanced.yml`](https://github.com/azohra/yaml.sh/blob/main/test/advanced.yml) and [`test/test.sh`](https://github.com/azohra/yaml.sh/blob/main/test/test.sh).

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -12,14 +12,14 @@
   <meta property="og:image" content="https://yaml.azohra.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="YAML.sh v1.0 — yq energy, zero baggage">
+  <meta property="og:image:alt" content="YAML.sh v1.1 — yq energy, zero baggage">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="YAML.sh v1 — yq energy. zero baggage.">
   <meta name="twitter:description" content="A yq-like YAML query tool in one portable shell script.">
   <meta name="twitter:image" content="https://yaml.azohra.com/og.png">
   <link rel="canonical" href="https://yaml.azohra.com">
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" href="css/style.css?v=1.0.0">
+  <link rel="stylesheet" href="css/style.css?v=1.1.0">
   <title>YAML.sh v1 — yq energy. zero baggage.</title>
 </head>
 <body>
@@ -41,7 +41,7 @@
   <main id="main">
     <section class="hero section-shell">
       <div class="hero-copy">
-        <p class="eyebrow"><span class="status-dot"></span> Version 1.0 · rebuilt from the nodes up</p>
+        <p class="eyebrow"><span class="status-dot"></span> Version 1.1 · now the nodes can flow</p>
         <h1>yq energy.<br><span>zero baggage.</span></h1>
         <p class="hero-lede">Query YAML with one portable shell script. No package manager. No language runtime. No mystery binary. Just <code>/bin/sh</code>, AWK, and a surprising amount of ambition.</p>
         <div class="hero-actions">
@@ -51,7 +51,7 @@
         <ul class="hero-facts" aria-label="YAML.sh highlights">
           <li><strong>1</strong> file</li>
           <li><strong>0</strong> extra packages</li>
-          <li><strong>37</strong> behavioral tests</li>
+          <li><strong>47</strong> behavioral tests</li>
         </ul>
       </div>
 
@@ -63,20 +63,21 @@
         </div>
         <div class="terminal-body">
           <div class="yaml-preview" aria-label="Example YAML input">
-            <p><span class="line-no">1</span><span class="key">server</span>:</p>
-            <p><span class="line-no">2</span>&nbsp;&nbsp;<span class="key">host</span>: <span class="string">localhost</span></p>
-            <p><span class="line-no">3</span>&nbsp;&nbsp;<span class="key">port</span>: <span class="number">8080</span></p>
-            <p><span class="line-no">4</span><span class="key">features</span>:</p>
-            <p><span class="line-no">5</span>&nbsp;&nbsp;- <span class="string">aliases</span></p>
-            <p><span class="line-no">6</span>&nbsp;&nbsp;- <span class="string">merge keys</span></p>
+            <p><span class="line-no">1</span><span class="key">services</span>:</p>
+            <p><span class="line-no">2</span>&nbsp;&nbsp;- <span class="key">name</span>: <span class="string">api</span></p>
+            <p><span class="line-no">3</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="key">enabled</span>: <span class="number">true</span></p>
+            <p><span class="line-no">4</span>&nbsp;&nbsp;- <span class="key">name</span>: <span class="string">worker</span></p>
+            <p><span class="line-no">5</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="key">enabled</span>: <span class="number">false</span></p>
+            <p><span class="line-no">6</span>&nbsp;&nbsp;- <span class="key">name</span>: <span class="string">web</span></p>
+            <p><span class="line-no">7</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="key">enabled</span>: <span class="number">true</span></p>
           </div>
           <div class="terminal-command">
-            <span class="prompt">$</span> ysh <span class="query">'.server.port'</span> config.yml
+            <span class="prompt">$</span> ysh <span class="query">'.services[] | select(.enabled) | .name'</span> config.yml
           </div>
-          <div class="terminal-output"><span>8080</span><i class="cursor" aria-hidden="true"></i></div>
+          <div class="terminal-output"><span>api<br>web</span><i class="cursor" aria-hidden="true"></i></div>
         </div>
         <div class="terminal-footer">
-          <span>node graph → resolver → query</span>
+          <span>node graph → resolver → expression stream</span>
           <span class="success">● parsed</span>
         </div>
       </div>
@@ -84,7 +85,7 @@
 
     <section class="ticker" aria-label="Core capabilities">
       <div>
-        <span>YQ-STYLE PATHS</span><b>◆</b>
+        <span>PIPES + SELECT</span><b>◆</b>
         <span>ANCHORS + ALIASES</span><b>◆</b>
         <span>MERGE KEYS</span><b>◆</b>
         <span>TAGS + TYPES</span><b>◆</b>
@@ -115,7 +116,7 @@
         <article>
           <span class="step">03</span>
           <h3>Query</h3>
-          <p>One path language selects real nodes—including empty collections and keys containing punctuation.</p>
+          <p>Paths, iteration, pipes, filters, comparisons, and defaults stream real node references without flattening them.</p>
         </article>
       </div>
     </section>
@@ -133,9 +134,10 @@
           <button id="tab-inspect" role="tab" aria-selected="false" aria-controls="panel-inspect" data-demo="inspect">Inspect</button>
         </div>
         <div class="demo-panel" id="panel-query" role="tabpanel" aria-labelledby="tab-query">
-          <p class="demo-label">Ask for exactly what you need.</p>
-          <pre><code><span class="prompt">$</span> ysh '.services[0].name' config.yml
-api</code></pre>
+          <p class="demo-label">Stream, filter, then ask for exactly what you need.</p>
+          <pre><code><span class="prompt">$</span> ysh '.services[] | select(.enabled) | .name' config.yml
+api
+web</code></pre>
         </div>
         <div class="demo-panel" id="panel-json" role="tabpanel" aria-labelledby="tab-json" hidden>
           <p class="demo-label">Collections become clean, typed JSON.</p>
@@ -197,7 +199,7 @@ node  1  mapping  line=1</code></pre>
         <p>The installer downloads a pinned release and places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
       </div>
       <div class="install-command">
-        <div class="install-command-label"><span>Terminal</span><span>v1.0.0</span></div>
+        <div class="install-command-label"><span>Terminal</span><span>v1.1.0</span></div>
         <pre><code id="install-code">curl -fsSL https://yaml.azohra.com/install | sh</code></pre>
         <button class="copy-button" type="button" data-copy="install-code"><span>Copy command</span><b aria-hidden="true">⌘</b></button>
         <p class="install-note">Prefer to inspect first? <a href="/install">Read the installer source.</a></p>

--- a/_static/_www/install
+++ b/_static/_www/install
@@ -5,6 +5,6 @@ install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.0.0/ysh -o "${temporary_file}"
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o "${temporary_file}"
 mkdir -p "${install_dir}"
 install -m 755 "${temporary_file}" "${install_dir}/ysh"

--- a/src/ysh.awk
+++ b/src/ysh.awk
@@ -934,110 +934,331 @@ function mapping_lookup(mapping, key) {
     return mapping_lookup_internal(mapping, key, ++lookup_serial)
 }
 
-function parse_query(query,    i, start, char, content, quote, escaped, end, segment) {
-    query_segment_count = 0
-    if (query == ".") {
-        return
+function expression_token_name(type) {
+    if (type == "end") {
+        return "end of expression"
     }
-    if (substr(query, 1, 1) != ".") {
-        fail("query must start with .")
+    if (expression_token_value != "") {
+        return expression_token_value
     }
-
-    i = 2
-    while (i <= length(query)) {
-        char = substr(query, i, 1)
-        if (char == ".") {
-            i++
-            if (i > length(query)) {
-                fail("query cannot end with .")
-            }
-            char = substr(query, i, 1)
-        }
-
-        if (char == "[") {
-            start = i + 1
-            quote = substr(query, start, 1)
-            escaped = 0
-            end = 0
-            for (i = start; i <= length(query); i++) {
-                char = substr(query, i, 1)
-                if (escaped) {
-                    escaped = 0
-                    continue
-                }
-                if (quote == "\"" && char == "\\") {
-                    escaped = 1
-                    continue
-                }
-                if ((quote == "\"" || quote == sprintf("%c", 39)) && i > start && char == quote && substr(query, i + 1, 1) == "]") {
-                    end = i + 1
-                    content = substr(query, start, i - start + 1)
-                    break
-                }
-                if (quote != "\"" && quote != sprintf("%c", 39) && char == "]") {
-                    end = i
-                    content = substr(query, start, i - start)
-                    break
-                }
-            }
-            if (!end) {
-                fail("unclosed query bracket")
-            }
-            segment = ++query_segment_count
-            if ((substr(content, 1, 1) == "\"" && substr(content, length(content), 1) == "\"") ||
-                (substr(content, 1, 1) == sprintf("%c", 39) && substr(content, length(content), 1) == sprintf("%c", 39))) {
-                query_segment_kind[segment] = "key"
-                query_segment_value[segment] = scalar_value(content)
-            } else if (content ~ /^[0-9]+$/) {
-                query_segment_kind[segment] = "index"
-                query_segment_value[segment] = content + 0
-            } else {
-                fail("query brackets require an index or quoted key")
-            }
-            i = end + 1
-            continue
-        }
-
-        start = i
-        while (i <= length(query) && substr(query, i, 1) != "." && substr(query, i, 1) != "[") {
-            i++
-        }
-        content = substr(query, start, i - start)
-        if (content == "") {
-            fail("empty query segment")
-        }
-        segment = ++query_segment_count
-        query_segment_kind[segment] = "key"
-        query_segment_value[segment] = content
-    }
+    return type
 }
 
-function query_node(root, query,    node, resolved, i, item_index, child) {
-    parse_query(query)
-    node = root
-    for (i = 1; i <= query_segment_count; i++) {
-        resolved = resolve_alias(node)
-        if (query_segment_kind[i] == "key") {
-            if (node_kind[resolved] != "mapping") {
-                fail("cannot select key " query_segment_value[i] " from " node_kind[resolved])
+function expression_is_word_char(char) {
+    return char ~ /^[A-Za-z0-9_-]$/
+}
+
+function expression_token_is_key() {
+    return expression_token_type == "identifier" || expression_token_type == "and" ||
+        expression_token_type == "or" || expression_token_type == "not" ||
+        expression_token_type == "literal_true" || expression_token_type == "literal_false" ||
+        expression_token_type == "literal_null"
+}
+
+function expression_lex_next(    char, next_char, start, quote, escaped, word, lowered) {
+    while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /[[:space:]]/) {
+        expression_position++
+    }
+    expression_token_value = ""
+    if (expression_position > length(expression_source)) {
+        expression_token_type = "end"
+        return
+    }
+
+    char = substr(expression_source, expression_position, 1)
+    next_char = substr(expression_source, expression_position + 1, 1)
+    if (char next_char == "//") {
+        expression_token_type = "alternative"
+        expression_token_value = "//"
+        expression_position += 2
+        return
+    }
+    if (char next_char == "==" || char next_char == "!=" || char next_char == ">=" || char next_char == "<=") {
+        expression_token_type = "compare"
+        expression_token_value = char next_char
+        expression_position += 2
+        return
+    }
+    if (char == ">" || char == "<") {
+        expression_token_type = "compare"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ".") {
+        expression_token_type = "dot"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "|") {
+        expression_token_type = "pipe"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "(") {
+        expression_token_type = "left_parenthesis"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ")") {
+        expression_token_type = "right_parenthesis"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "[") {
+        expression_token_type = "left_bracket"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "]") {
+        expression_token_type = "right_bracket"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ",") {
+        expression_token_type = "comma"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+
+    quote = sprintf("%c", 39)
+    if (char == "\"" || char == quote) {
+        start = expression_position
+        quote = char
+        escaped = 0
+        expression_position++
+        while (expression_position <= length(expression_source)) {
+            char = substr(expression_source, expression_position, 1)
+            if (escaped) {
+                escaped = 0
+            } else if (quote == "\"" && char == "\\") {
+                escaped = 1
+            } else if (char == quote) {
+                expression_position++
+                expression_token_type = "string"
+                expression_token_value = scalar_value(substr(expression_source, start, expression_position - start))
+                return
             }
-            child = mapping_lookup(resolved, query_segment_value[i])
-            if (!child) {
-                fail("query key not found: " query_segment_value[i])
-            }
-            node = child
+            expression_position++
+        }
+        fail("unterminated string in expression")
+    }
+
+    if (char ~ /^[0-9]$/ || (char == "-" && next_char ~ /^[0-9]$/)) {
+        start = expression_position
+        expression_position++
+        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9.eE_+-]$/) {
+            expression_position++
+        }
+        expression_token_type = "number"
+        expression_token_value = substr(expression_source, start, expression_position - start)
+        return
+    }
+
+    if (expression_is_word_char(char)) {
+        start = expression_position
+        while (expression_position <= length(expression_source) && expression_is_word_char(substr(expression_source, expression_position, 1))) {
+            expression_position++
+        }
+        word = substr(expression_source, start, expression_position - start)
+        lowered = tolower(word)
+        if (lowered == "and" || lowered == "or" || lowered == "not") {
+            expression_token_type = lowered
+        } else if (lowered == "true" || lowered == "false" || lowered == "null") {
+            expression_token_type = "literal_" lowered
         } else {
-            if (node_kind[resolved] != "sequence") {
-                fail("cannot select an index from " node_kind[resolved])
+            expression_token_type = "identifier"
+        }
+        expression_token_value = word
+        return
+    }
+    fail("unexpected character in expression: " char)
+}
+
+function expression_new(kind, left, right, value,    expression) {
+    expression = ++expression_count
+    expression_kind[expression] = kind
+    expression_left[expression] = left
+    expression_right[expression] = right
+    expression_value[expression] = value
+    return expression
+}
+
+function expression_expect(type,    actual) {
+    if (expression_token_type != type) {
+        actual = expression_token_name(expression_token_type)
+        fail("expected " type " but found " actual)
+    }
+    expression_lex_next()
+}
+
+function expression_parse_primary(    expression, name, step, argument, value, value_type) {
+    if (expression_token_type == "dot") {
+        expression = expression_new("identity", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_is_key()) {
+            expression = expression_new("key", expression, 0, expression_token_value)
+            expression_lex_next()
+        }
+    } else if (expression_token_type == "string") {
+        expression = expression_new("literal", 0, 0, expression_token_value)
+        expression_literal_type[expression] = "string"
+        expression_lex_next()
+    } else if (expression_token_type == "number") {
+        value = expression_token_value
+        value_type = scalar_type(value, "", value)
+        if (value_type != "int" && value_type != "float") {
+            fail("invalid numeric literal: " value)
+        }
+        expression = expression_new("literal", 0, 0, value)
+        expression_literal_type[expression] = value_type
+        expression_lex_next()
+    } else if (expression_token_type == "literal_true" || expression_token_type == "literal_false") {
+        expression = expression_new("literal", 0, 0, tolower(expression_token_value))
+        expression_literal_type[expression] = "bool"
+        expression_lex_next()
+    } else if (expression_token_type == "literal_null") {
+        expression = expression_new("literal", 0, 0, "")
+        expression_literal_type[expression] = "null"
+        expression_lex_next()
+    } else if (expression_token_type == "left_parenthesis") {
+        expression_lex_next()
+        expression = expression_parse_pipe()
+        expression_expect("right_parenthesis")
+    } else if (expression_token_type == "identifier") {
+        name = tolower(expression_token_value)
+        expression_lex_next()
+        if (name == "select" || name == "has") {
+            expression_expect("left_parenthesis")
+            argument = expression_parse_pipe()
+            expression_expect("right_parenthesis")
+            expression = expression_new(name, argument, 0, "")
+        } else if (name == "length" || name == "keys" || name == "kind" || name == "type") {
+            if (expression_token_type == "left_parenthesis") {
+                expression_lex_next()
+                expression_expect("right_parenthesis")
             }
-            item_index = query_segment_value[i]
-            if (item_index < 0 || item_index >= sequence_count[resolved]) {
-                fail("query index out of range: " item_index)
+            expression = expression_new(name, 0, 0, "")
+        } else {
+            fail("unknown expression operator: " name)
+        }
+    } else {
+        fail("expected expression but found " expression_token_name(expression_token_type))
+    }
+
+    while (1) {
+        if (expression_token_type == "dot") {
+            expression_lex_next()
+            if (!expression_token_is_key()) {
+                fail("expected a key after .")
             }
-            node = sequence_child[resolved, item_index + 1]
+            expression = expression_new("key", expression, 0, expression_token_value)
+            expression_lex_next()
+        } else if (expression_token_type == "left_bracket") {
+            expression_lex_next()
+            if (expression_token_type == "right_bracket") {
+                expression = expression_new("each", expression, 0, "")
+                expression_lex_next()
+            } else if (expression_token_type == "number") {
+                if (expression_token_value !~ /^[0-9]+$/) {
+                    fail("sequence indexes must be non-negative integers")
+                }
+                step = expression_token_value + 0
+                expression_lex_next()
+                expression_expect("right_bracket")
+                expression = expression_new("index", expression, 0, step)
+            } else if (expression_token_type == "string") {
+                step = expression_token_value
+                expression_lex_next()
+                expression_expect("right_bracket")
+                expression = expression_new("key", expression, 0, step)
+            } else {
+                fail("brackets require an index, quoted key, or empty iterator")
+            }
+        } else {
+            break
         }
     }
-    return node
+    return expression
+}
+
+function expression_parse_unary(    operand) {
+    if (expression_token_type == "not") {
+        expression_lex_next()
+        operand = expression_new("identity", 0, 0, "")
+        return expression_new("not", operand, 0, "")
+    }
+    return expression_parse_primary()
+}
+
+function expression_parse_compare(    left, operator, right) {
+    left = expression_parse_unary()
+    while (expression_token_type == "compare") {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_unary()
+        left = expression_new("compare", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_and(    left, right) {
+    left = expression_parse_compare()
+    while (expression_token_type == "and") {
+        expression_lex_next()
+        right = expression_parse_compare()
+        left = expression_new("and", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_or(    left, right) {
+    left = expression_parse_and()
+    while (expression_token_type == "or") {
+        expression_lex_next()
+        right = expression_parse_and()
+        left = expression_new("or", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_alternative(    left, right) {
+    left = expression_parse_or()
+    while (expression_token_type == "alternative") {
+        expression_lex_next()
+        right = expression_parse_or()
+        left = expression_new("alternative", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_pipe(    left, right) {
+    left = expression_parse_alternative()
+    while (expression_token_type == "pipe") {
+        expression_lex_next()
+        right = expression_parse_alternative()
+        left = expression_new("pipe", left, right, "")
+    }
+    return left
+}
+
+function expression_parse(source,    expression) {
+    expression_source = source
+    expression_position = 1
+    expression_count = 0
+    expression_lex_next()
+    expression = expression_parse_pipe()
+    if (expression_token_type != "end") {
+        fail("unexpected token after expression: " expression_token_name(expression_token_type))
+    }
+    return expression
 }
 
 function collect_keys_from_source(source, collection,    resolved, i) {
@@ -1075,6 +1296,347 @@ function collect_mapping_keys(mapping, collection,    stack_key, seen_key, i, ke
         }
     }
     delete collection_stack[stack_key]
+}
+
+function expression_stream_new() {
+    return ++expression_stream_serial
+}
+
+function expression_stream_push(stream, node) {
+    expression_stream_node[stream, ++expression_stream_count[stream]] = node
+}
+
+function expression_stream_single(node,    stream) {
+    stream = expression_stream_new()
+    expression_stream_push(stream, node)
+    return stream
+}
+
+function expression_stream_append(target, source,    i) {
+    for (i = 1; i <= expression_stream_count[source]; i++) {
+        expression_stream_push(target, expression_stream_node[source, i])
+    }
+}
+
+function expression_scalar(value, value_type) {
+    return new_node("scalar", 0, value, value_type, "")
+}
+
+function expression_boolean(value) {
+    if (value) {
+        return expression_scalar("true", "bool")
+    }
+    return expression_scalar("false", "bool")
+}
+
+function expression_null() {
+    return expression_scalar("", "null")
+}
+
+function expression_truthy(node,    resolved, lowered) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "scalar") {
+        return 1
+    }
+    if (node_type[resolved] == "null") {
+        return 0
+    }
+    if (node_type[resolved] == "bool") {
+        lowered = tolower(node_value[resolved])
+        return lowered != "false"
+    }
+    return 1
+}
+
+function expression_numeric(node,    resolved, value) {
+    resolved = resolve_alias(node)
+    if (node_type[resolved] == "int") {
+        return json_integer(node_value[resolved]) + 0
+    }
+    value = node_value[resolved]
+    gsub(/_/, "", value)
+    if (tolower(value) ~ /\.(inf|nan)$/) {
+        fail("non-finite numbers cannot be compared")
+    }
+    return value + 0
+}
+
+function expression_nodes_equal(left, right,    left_node, right_node) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "scalar" || node_kind[right_node] != "scalar") {
+        return 0
+    }
+    if (node_type[left_node] == "null" || node_type[right_node] == "null") {
+        return node_type[left_node] == "null" && node_type[right_node] == "null"
+    }
+    if ((node_type[left_node] == "int" || node_type[left_node] == "float") &&
+        (node_type[right_node] == "int" || node_type[right_node] == "float")) {
+        return expression_numeric(left_node) == expression_numeric(right_node)
+    }
+    if (node_type[left_node] == "bool" && node_type[right_node] == "bool") {
+        return tolower(node_value[left_node]) == tolower(node_value[right_node])
+    }
+    return node_value[left_node] == node_value[right_node]
+}
+
+function expression_compare(left, right, operator,    left_node, right_node, left_value, right_value, equal) {
+    equal = expression_nodes_equal(left, right)
+    if (operator == "==") {
+        return equal
+    }
+    if (operator == "!=") {
+        return !equal
+    }
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "scalar" || node_kind[right_node] != "scalar") {
+        fail("ordering comparisons require scalar values")
+    }
+    if ((node_type[left_node] == "int" || node_type[left_node] == "float") &&
+        (node_type[right_node] == "int" || node_type[right_node] == "float")) {
+        left_value = expression_numeric(left_node)
+        right_value = expression_numeric(right_node)
+    } else if (node_type[left_node] == "string" && node_type[right_node] == "string") {
+        left_value = node_value[left_node]
+        right_value = node_value[right_node]
+    } else {
+        fail("ordering comparisons require two numbers or two strings")
+    }
+    if (operator == ">") {
+        return left_value > right_value
+    }
+    if (operator == ">=") {
+        return left_value >= right_value
+    }
+    if (operator == "<") {
+        return left_value < right_value
+    }
+    return left_value <= right_value
+}
+
+function expression_mapping_length(node,    collection) {
+    collection = ++collection_serial
+    collect_mapping_keys(node, collection)
+    return collection_count[collection]
+}
+
+function expression_kind_name(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] == "mapping") {
+        return "map"
+    }
+    if (node_kind[resolved] == "sequence") {
+        return "seq"
+    }
+    return "scalar"
+}
+
+function expression_type_name(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_tag[resolved] != "") {
+        if (node_tag[resolved] ~ /^tag:yaml.org,2002:/) {
+            return "!!" substr(node_tag[resolved], length("tag:yaml.org,2002:") + 1)
+        }
+        return node_tag[resolved]
+    }
+    if (node_kind[resolved] == "mapping") {
+        return "!!map"
+    }
+    if (node_kind[resolved] == "sequence") {
+        return "!!seq"
+    }
+    if (node_type[resolved] == "string") {
+        return "!!str"
+    }
+    if (node_type[resolved] == "tagged") {
+        return "!"
+    }
+    return "!!" node_type[resolved]
+}
+
+function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
+    output = expression_stream_new()
+    kind = expression_kind[expression]
+
+    if (kind == "identity") {
+        expression_stream_append(output, input)
+        return output
+    }
+    if (kind == "literal") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "pipe") {
+        middle = expression_evaluate(expression_left[expression], input)
+        return expression_evaluate(expression_right[expression], middle)
+    }
+    if (kind == "key" || kind == "index" || kind == "each") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = expression_stream_node[middle, i]
+            resolved = resolve_alias(node)
+            if (kind == "key") {
+                if (node_kind[resolved] == "mapping") {
+                    child = mapping_lookup(resolved, expression_value[expression])
+                } else {
+                    child = 0
+                }
+                expression_stream_push(output, child ? child : expression_null())
+            } else if (kind == "index") {
+                if (node_kind[resolved] == "sequence" && expression_value[expression] < sequence_count[resolved]) {
+                    child = sequence_child[resolved, expression_value[expression] + 1]
+                } else {
+                    child = 0
+                }
+                expression_stream_push(output, child ? child : expression_null())
+            } else if (node_kind[resolved] == "sequence") {
+                for (j = 1; j <= sequence_count[resolved]; j++) {
+                    expression_stream_push(output, sequence_child[resolved, j])
+                }
+            } else if (node_kind[resolved] == "mapping") {
+                collection = ++collection_serial
+                collect_mapping_keys(resolved, collection)
+                for (j = 1; j <= collection_count[collection]; j++) {
+                    key = collection_key[collection, j]
+                    expression_stream_push(output, mapping_lookup(resolved, key))
+                }
+            } else {
+                if (node_kind[resolved] == "scalar") {
+                    fail("cannot iterate over " node_type[resolved])
+                }
+                fail("cannot iterate over " node_kind[resolved])
+            }
+        }
+        return output
+    }
+    if (kind == "select") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            single = expression_stream_single(node)
+            predicate = expression_evaluate(expression_left[expression], single)
+            matched = 0
+            for (j = 1; j <= expression_stream_count[predicate]; j++) {
+                if (expression_truthy(expression_stream_node[predicate, j])) {
+                    matched = 1
+                    break
+                }
+            }
+            if (matched) {
+                expression_stream_push(output, node)
+            }
+        }
+        return output
+    }
+    if (kind == "compare" || kind == "and" || kind == "or") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                for (collection = 1; collection <= expression_stream_count[right_stream]; collection++) {
+                    node = expression_stream_node[left_stream, j]
+                    child = expression_stream_node[right_stream, collection]
+                    if (kind == "compare") {
+                        matched = expression_compare(node, child, expression_value[expression])
+                    } else if (kind == "and") {
+                        matched = expression_truthy(node) && expression_truthy(child)
+                    } else {
+                        matched = expression_truthy(node) || expression_truthy(child)
+                    }
+                    expression_stream_push(output, expression_boolean(matched))
+                }
+            }
+        }
+        return output
+    }
+    if (kind == "not") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            expression_stream_push(output, expression_boolean(!expression_truthy(expression_stream_node[middle, i])))
+        }
+        return output
+    }
+    if (kind == "alternative") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            matched = 0
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                node = expression_stream_node[left_stream, j]
+                if (expression_truthy(node)) {
+                    expression_stream_push(output, node)
+                    matched = 1
+                }
+            }
+            if (!matched) {
+                right_stream = expression_evaluate(expression_right[expression], single)
+                expression_stream_append(output, right_stream)
+            }
+        }
+        return output
+    }
+    if (kind == "length" || kind == "keys" || kind == "kind" || kind == "type" || kind == "has") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            resolved = resolve_alias(node)
+            if (kind == "length") {
+                if (node_kind[resolved] == "mapping") {
+                    matched = expression_mapping_length(resolved)
+                } else if (node_kind[resolved] == "sequence") {
+                    matched = sequence_count[resolved]
+                } else if (node_type[resolved] == "null") {
+                    matched = 0
+                } else {
+                    matched = length(node_value[resolved])
+                }
+                expression_stream_push(output, expression_scalar(matched "", "int"))
+            } else if (kind == "kind") {
+                expression_stream_push(output, expression_scalar(expression_kind_name(resolved), "string"))
+            } else if (kind == "type") {
+                expression_stream_push(output, expression_scalar(expression_type_name(resolved), "string"))
+            } else if (kind == "keys") {
+                result_node = new_node("sequence", 0, "", "", "")
+                if (node_kind[resolved] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(resolved, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        add_sequence(result_node, expression_scalar(collection_key[collection, j], "string"), 0)
+                    }
+                } else if (node_kind[resolved] == "sequence") {
+                    for (j = 0; j < sequence_count[resolved]; j++) {
+                        add_sequence(result_node, expression_scalar(j "", "int"), 0)
+                    }
+                } else {
+                    fail("keys requires a mapping or sequence")
+                }
+                expression_stream_push(output, result_node)
+            } else {
+                single = expression_stream_single(node)
+                argument_stream = expression_evaluate(expression_left[expression], single)
+                if (expression_stream_count[argument_stream] < 1) {
+                    expression_stream_push(output, expression_boolean(0))
+                    continue
+                }
+                argument = resolve_alias(expression_stream_node[argument_stream, 1])
+                if (node_kind[argument] != "scalar") {
+                    fail("has requires a scalar key or index")
+                }
+                if (node_kind[resolved] == "mapping") {
+                    matched = mapping_lookup(resolved, node_value[argument]) != 0
+                } else if (node_kind[resolved] == "sequence" && node_type[argument] == "int") {
+                    matched = (node_value[argument] + 0) >= 0 && (node_value[argument] + 0) < sequence_count[resolved]
+                } else {
+                    matched = 0
+                }
+                expression_stream_push(output, expression_boolean(matched))
+            }
+        }
+        return output
+    }
+    fail("cannot evaluate expression kind " kind)
 }
 
 function base_integer(value, base,    result, i, char, digit) {
@@ -1265,23 +1827,8 @@ function output_events(document) {
     print "STREAM_END"
 }
 
-function output_result(document, query, output_mode,    root, target, resolved) {
-    if (!(document in document_root)) {
-        fail("document index not found: " document)
-    }
-    if (output_mode == "ast") {
-        output_ast(document)
-        return
-    }
-    if (output_mode == "events") {
-        output_events(document)
-        return
-    }
-
-    root = document_root[document]
-    target = query_node(root, query)
+function output_expression_node(target, output_mode,    resolved) {
     resolved = resolve_alias(target)
-
     if (output_mode == "line") {
         print node_line[target]
     } else if (output_mode == "type") {
@@ -1300,6 +1847,28 @@ function output_result(document, query, output_mode,    root, target, resolved) 
     } else {
         emit_json(target)
         printf "\n"
+    }
+}
+
+function output_result(document, query, output_mode,    root, expression, input, results, i) {
+    if (!(document in document_root)) {
+        fail("document index not found: " document)
+    }
+    if (output_mode == "ast") {
+        output_ast(document)
+        return
+    }
+    if (output_mode == "events") {
+        output_events(document)
+        return
+    }
+
+    root = document_root[document]
+    expression = expression_parse(query)
+    input = expression_stream_single(root)
+    results = expression_evaluate(expression, input)
+    for (i = 1; i <= expression_stream_count[results]; i++) {
+        output_expression_node(expression_stream_node[results, i], output_mode)
     }
 }
 

--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.0.0
+YSH_VERSION=1.1.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER=$(cat src/ysh.awk)
@@ -20,7 +20,9 @@ Usage:
 
 Examples:
   ysh ".server.host" config.yml
-  ysh ".services[0]" config.yml --json
+  ysh ".services[] | select(.enabled) | .name" config.yml
+  ysh ".services | length" config.yml
+  ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
   printf "%s\\n" "answer: 42" | ysh ".answer"
 
@@ -41,8 +43,9 @@ Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY uses yq-style paths such as .server.host, .items[0], and
-.["key.with.dots"]. Collections are emitted as JSON by default.
+QUERY supports yq-style paths, [], pipes, select, comparisons, boolean
+operators, // defaults, length, keys, has, kind, and type. Collections
+are emitted as JSON by default; streams emit one result per line.
 EOF
 }
 
@@ -192,16 +195,20 @@ ysh_main() {
                 YSH_INPUT_FILE=$YSH_POSITIONAL_ONE
                 YSH_QUERY=$YSH_POSITIONAL_TWO
             else
-                ysh_error "query must start with ."
-                return 2
+                YSH_QUERY=$YSH_POSITIONAL_ONE
+                YSH_INPUT_FILE=$YSH_POSITIONAL_TWO
             fi
             ;;
         esac
     elif [ "$YSH_POSITIONAL_COUNT" -eq 1 ]; then
-        case "$YSH_POSITIONAL_ONE" in
-        .*) YSH_QUERY=$YSH_POSITIONAL_ONE ;;
-        *) YSH_INPUT_FILE=$YSH_POSITIONAL_ONE ;;
-        esac
+        if [ -f "$YSH_POSITIONAL_ONE" ] || [ "$YSH_POSITIONAL_ONE" = "-" ]; then
+            YSH_INPUT_FILE=$YSH_POSITIONAL_ONE
+        else
+            case "$YSH_POSITIONAL_ONE" in
+            *.yml|*.yaml|*.json) YSH_INPUT_FILE=$YSH_POSITIONAL_ONE ;;
+            *) YSH_QUERY=$YSH_POSITIONAL_ONE ;;
+            esac
+        fi
     fi
 
     if [ -n "$YSH_INPUT_FILE" ] && [ "$YSH_INPUT_FILE" != "-" ] && [ ! -f "$YSH_INPUT_FILE" ]; then

--- a/test/expressions.yml
+++ b/test/expressions.yml
@@ -1,0 +1,19 @@
+services:
+  - name: api
+    enabled: true
+    port: 8080
+    tier: backend
+  - name: worker
+    enabled: false
+    port: 9090
+    tier: backend
+  - name: web
+    enabled: true
+    port: 3000
+    tier: frontend
+metadata:
+  owner: platform
+  region: west
+empty: []
+unset: null
+disabled: false

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 testVersion() {
-    assertEquals "v1.0.0" "$(./ysh --version)"
+    assertEquals "v1.1.0" "$(./ysh --version)"
 }
 
 testHelp() {
@@ -96,6 +96,81 @@ testEmptyCollectionsSurviveParsing() {
 testQuotedQueryKeys() {
     assertEquals "dotted" "$(./ysh '.["key.with.dots"]' test/advanced.yml)"
     assertEquals "dotted" "$(./ysh ".[\"key.with.dots\"]" test/advanced.yml)"
+}
+
+testExpressionIterationAndPipes() {
+    assertEquals "$(printf "%s\n" api worker web)" "$(./ysh '.services[].name' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" api worker web)" "$(./ysh '.services[] | .name' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" platform west)" "$(./ysh '.metadata[]' test/expressions.yml)"
+}
+
+testExpressionSelectAndComparisons() {
+    assertEquals "$(printf "%s\n" api web)" "$(./ysh '.services[] | select(.enabled == true) | .name' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" api worker)" "$(./ysh '.services[] | select(.port >= 8080) | .name' test/expressions.yml)"
+    assertEquals "web" "$(./ysh '.services[] | select(.tier == "frontend") | .name' test/expressions.yml)"
+    assertEquals "worker" "$(./ysh '.services[] | select(.name != "api" and .enabled == false) | .name' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" true true false)" "$(./ysh '.services[] | .port >= 8080' test/expressions.yml)"
+}
+
+testExpressionBooleanFilters() {
+    assertEquals "$(printf "%s\n" api web)" "$(./ysh '.services[] | select(.enabled and .port < 9000) | .name' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" false true false)" "$(./ysh '.services[] | .enabled | not' test/expressions.yml)"
+    assertEquals "$(printf "%s\n" api web)" "$(./ysh '.services[] | select(.enabled) | .name' test/expressions.yml)"
+}
+
+testExpressionAlternativeDefaults() {
+    assertEquals "fallback" "$(./ysh '.missing // "fallback"' test/expressions.yml)"
+    assertEquals "fallback" "$(./ysh '.unset // "fallback"' test/expressions.yml)"
+    assertEquals "fallback" "$(./ysh '.disabled // "fallback"' test/expressions.yml)"
+    assertEquals "platform" "$(./ysh '.metadata.owner // "fallback"' test/expressions.yml)"
+}
+
+testExpressionCollectionHelpers() {
+    assertEquals "3" "$(./ysh '.services | length' test/expressions.yml)"
+    assertEquals "8" "$(./ysh '.metadata.owner | length' test/expressions.yml)"
+    assertEquals '["owner","region"]' "$(./ysh '.metadata | keys' test/expressions.yml)"
+    assertEquals '[0,1,2]' "$(./ysh '.services | keys' test/expressions.yml)"
+    assertEquals "true" "$(./ysh '.metadata | has("owner")' test/expressions.yml)"
+    assertEquals "false" "$(./ysh '.metadata | has("missing")' test/expressions.yml)"
+    assertEquals "true" "$(./ysh '.services | has(2)' test/expressions.yml)"
+    assertEquals "false" "$(./ysh '.services | has(9)' test/expressions.yml)"
+}
+
+testExpressionKindAndType() {
+    assertEquals "map" "$(./ysh '.metadata | kind' test/expressions.yml)"
+    assertEquals "seq" "$(./ysh '.services | kind' test/expressions.yml)"
+    assertEquals "scalar" "$(./ysh '.services[0].name | kind' test/expressions.yml)"
+    assertEquals "!!int" "$(./ysh '.services[0].port | type' test/expressions.yml)"
+    assertEquals "!!bool" "$(./ysh '.services[0].enabled | type' test/expressions.yml)"
+}
+
+testExpressionMissingValuesAreNull() {
+    assertEquals "null" "$(./ysh --json '.missing' test/expressions.yml)"
+    assertEquals "null" "$(./ysh --json '.services[99]' test/expressions.yml)"
+    assertEquals "null" "$(./ysh --json '.services[0].missing' test/expressions.yml)"
+}
+
+testExpressionBareRootFilters() {
+    assertEquals "5" "$(./ysh 'length' test/expressions.yml)"
+    assertEquals "2" "$(printf '%s\n' '[one, two]' | ./ysh 'length')"
+}
+
+testExpressionJsonStreams() {
+    assertEquals "$(printf '%s\n' '{"name":"api","enabled":true,"port":8080,"tier":"backend"}' '{"name":"web","enabled":true,"port":3000,"tier":"frontend"}')" "$(./ysh --json '.services[] | select(.enabled)' test/expressions.yml)"
+}
+
+testExpressionErrors() {
+    result=$(./ysh '.services[] | select(' test/expressions.yml 2>&1)
+    assertNotEquals 0 $?
+    assertContains "$result" "expected expression"
+
+    result=$(./ysh '.metadata.owner[]' test/expressions.yml 2>&1)
+    assertNotEquals 0 $?
+    assertContains "$result" "cannot iterate over string"
+
+    result=$(./ysh '.services | mystery' test/expressions.yml 2>&1)
+    assertNotEquals 0 $?
+    assertContains "$result" "unknown expression operator"
 }
 
 testScalarAndCollectionTypes() {
@@ -216,17 +291,9 @@ testMalformedYamlIsRejected() {
 }
 
 testQueryErrors() {
-    result=$(./ysh ".missing" test/test.yml 2>&1)
-    assertNotEquals 0 $?
-    assertContains "$result" "query key not found"
-
     result=$(./ysh "missing" test/test.yml 2>&1)
     assertNotEquals 0 $?
-    assertContains "$result" "query must start with ."
-
-    result=$(./ysh ".simple_list.list[99]" test/test.yml 2>&1)
-    assertNotEquals 0 $?
-    assertContains "$result" "query index out of range"
+    assertContains "$result" "unknown expression operator"
 }
 
 testCliErrors() {
@@ -245,12 +312,12 @@ testRunsWithPosixShell() {
 }
 
 testReleaseArtifactsStayInSync() {
-    assertContains "$(cat README.md)" "v1.0.0/ysh"
-    assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.0.0/ysh"
-    assertContains "$(cat _static/_www/install)" "v1.0.0/ysh"
+    assertContains "$(cat README.md)" "v1.1.0/ysh"
+    assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.1.0/ysh"
+    assertContains "$(cat _static/_www/install)" "v1.1.0/ysh"
     assertContains "$(cat _static/_www/index.html)" "Install v1"
-    assertContains "$(cat _static/_www/index.html)" "style.css?v=1.0.0"
-    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.0.0"
+    assertContains "$(cat _static/_www/index.html)" "style.css?v=1.1.0"
+    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.1.0"
     assertContains "$(cat _static/_www/docs/index.html)" "docsify@4/lib/themes/vue.css"
     assertTrue "social preview image must exist" "[ -s _static/_www/og.png ]"
 }

--- a/ysh
+++ b/ysh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.0.0
+YSH_VERSION=1.1.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER='
@@ -940,110 +940,331 @@ function mapping_lookup(mapping, key) {
     return mapping_lookup_internal(mapping, key, ++lookup_serial)
 }
 
-function parse_query(query,    i, start, char, content, quote, escaped, end, segment) {
-    query_segment_count = 0
-    if (query == ".") {
-        return
+function expression_token_name(type) {
+    if (type == "end") {
+        return "end of expression"
     }
-    if (substr(query, 1, 1) != ".") {
-        fail("query must start with .")
+    if (expression_token_value != "") {
+        return expression_token_value
     }
-
-    i = 2
-    while (i <= length(query)) {
-        char = substr(query, i, 1)
-        if (char == ".") {
-            i++
-            if (i > length(query)) {
-                fail("query cannot end with .")
-            }
-            char = substr(query, i, 1)
-        }
-
-        if (char == "[") {
-            start = i + 1
-            quote = substr(query, start, 1)
-            escaped = 0
-            end = 0
-            for (i = start; i <= length(query); i++) {
-                char = substr(query, i, 1)
-                if (escaped) {
-                    escaped = 0
-                    continue
-                }
-                if (quote == "\"" && char == "\\") {
-                    escaped = 1
-                    continue
-                }
-                if ((quote == "\"" || quote == sprintf("%c", 39)) && i > start && char == quote && substr(query, i + 1, 1) == "]") {
-                    end = i + 1
-                    content = substr(query, start, i - start + 1)
-                    break
-                }
-                if (quote != "\"" && quote != sprintf("%c", 39) && char == "]") {
-                    end = i
-                    content = substr(query, start, i - start)
-                    break
-                }
-            }
-            if (!end) {
-                fail("unclosed query bracket")
-            }
-            segment = ++query_segment_count
-            if ((substr(content, 1, 1) == "\"" && substr(content, length(content), 1) == "\"") ||
-                (substr(content, 1, 1) == sprintf("%c", 39) && substr(content, length(content), 1) == sprintf("%c", 39))) {
-                query_segment_kind[segment] = "key"
-                query_segment_value[segment] = scalar_value(content)
-            } else if (content ~ /^[0-9]+$/) {
-                query_segment_kind[segment] = "index"
-                query_segment_value[segment] = content + 0
-            } else {
-                fail("query brackets require an index or quoted key")
-            }
-            i = end + 1
-            continue
-        }
-
-        start = i
-        while (i <= length(query) && substr(query, i, 1) != "." && substr(query, i, 1) != "[") {
-            i++
-        }
-        content = substr(query, start, i - start)
-        if (content == "") {
-            fail("empty query segment")
-        }
-        segment = ++query_segment_count
-        query_segment_kind[segment] = "key"
-        query_segment_value[segment] = content
-    }
+    return type
 }
 
-function query_node(root, query,    node, resolved, i, item_index, child) {
-    parse_query(query)
-    node = root
-    for (i = 1; i <= query_segment_count; i++) {
-        resolved = resolve_alias(node)
-        if (query_segment_kind[i] == "key") {
-            if (node_kind[resolved] != "mapping") {
-                fail("cannot select key " query_segment_value[i] " from " node_kind[resolved])
+function expression_is_word_char(char) {
+    return char ~ /^[A-Za-z0-9_-]$/
+}
+
+function expression_token_is_key() {
+    return expression_token_type == "identifier" || expression_token_type == "and" ||
+        expression_token_type == "or" || expression_token_type == "not" ||
+        expression_token_type == "literal_true" || expression_token_type == "literal_false" ||
+        expression_token_type == "literal_null"
+}
+
+function expression_lex_next(    char, next_char, start, quote, escaped, word, lowered) {
+    while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /[[:space:]]/) {
+        expression_position++
+    }
+    expression_token_value = ""
+    if (expression_position > length(expression_source)) {
+        expression_token_type = "end"
+        return
+    }
+
+    char = substr(expression_source, expression_position, 1)
+    next_char = substr(expression_source, expression_position + 1, 1)
+    if (char next_char == "//") {
+        expression_token_type = "alternative"
+        expression_token_value = "//"
+        expression_position += 2
+        return
+    }
+    if (char next_char == "==" || char next_char == "!=" || char next_char == ">=" || char next_char == "<=") {
+        expression_token_type = "compare"
+        expression_token_value = char next_char
+        expression_position += 2
+        return
+    }
+    if (char == ">" || char == "<") {
+        expression_token_type = "compare"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ".") {
+        expression_token_type = "dot"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "|") {
+        expression_token_type = "pipe"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "(") {
+        expression_token_type = "left_parenthesis"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ")") {
+        expression_token_type = "right_parenthesis"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "[") {
+        expression_token_type = "left_bracket"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "]") {
+        expression_token_type = "right_bracket"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ",") {
+        expression_token_type = "comma"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+
+    quote = sprintf("%c", 39)
+    if (char == "\"" || char == quote) {
+        start = expression_position
+        quote = char
+        escaped = 0
+        expression_position++
+        while (expression_position <= length(expression_source)) {
+            char = substr(expression_source, expression_position, 1)
+            if (escaped) {
+                escaped = 0
+            } else if (quote == "\"" && char == "\\") {
+                escaped = 1
+            } else if (char == quote) {
+                expression_position++
+                expression_token_type = "string"
+                expression_token_value = scalar_value(substr(expression_source, start, expression_position - start))
+                return
             }
-            child = mapping_lookup(resolved, query_segment_value[i])
-            if (!child) {
-                fail("query key not found: " query_segment_value[i])
-            }
-            node = child
+            expression_position++
+        }
+        fail("unterminated string in expression")
+    }
+
+    if (char ~ /^[0-9]$/ || (char == "-" && next_char ~ /^[0-9]$/)) {
+        start = expression_position
+        expression_position++
+        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9.eE_+-]$/) {
+            expression_position++
+        }
+        expression_token_type = "number"
+        expression_token_value = substr(expression_source, start, expression_position - start)
+        return
+    }
+
+    if (expression_is_word_char(char)) {
+        start = expression_position
+        while (expression_position <= length(expression_source) && expression_is_word_char(substr(expression_source, expression_position, 1))) {
+            expression_position++
+        }
+        word = substr(expression_source, start, expression_position - start)
+        lowered = tolower(word)
+        if (lowered == "and" || lowered == "or" || lowered == "not") {
+            expression_token_type = lowered
+        } else if (lowered == "true" || lowered == "false" || lowered == "null") {
+            expression_token_type = "literal_" lowered
         } else {
-            if (node_kind[resolved] != "sequence") {
-                fail("cannot select an index from " node_kind[resolved])
+            expression_token_type = "identifier"
+        }
+        expression_token_value = word
+        return
+    }
+    fail("unexpected character in expression: " char)
+}
+
+function expression_new(kind, left, right, value,    expression) {
+    expression = ++expression_count
+    expression_kind[expression] = kind
+    expression_left[expression] = left
+    expression_right[expression] = right
+    expression_value[expression] = value
+    return expression
+}
+
+function expression_expect(type,    actual) {
+    if (expression_token_type != type) {
+        actual = expression_token_name(expression_token_type)
+        fail("expected " type " but found " actual)
+    }
+    expression_lex_next()
+}
+
+function expression_parse_primary(    expression, name, step, argument, value, value_type) {
+    if (expression_token_type == "dot") {
+        expression = expression_new("identity", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_is_key()) {
+            expression = expression_new("key", expression, 0, expression_token_value)
+            expression_lex_next()
+        }
+    } else if (expression_token_type == "string") {
+        expression = expression_new("literal", 0, 0, expression_token_value)
+        expression_literal_type[expression] = "string"
+        expression_lex_next()
+    } else if (expression_token_type == "number") {
+        value = expression_token_value
+        value_type = scalar_type(value, "", value)
+        if (value_type != "int" && value_type != "float") {
+            fail("invalid numeric literal: " value)
+        }
+        expression = expression_new("literal", 0, 0, value)
+        expression_literal_type[expression] = value_type
+        expression_lex_next()
+    } else if (expression_token_type == "literal_true" || expression_token_type == "literal_false") {
+        expression = expression_new("literal", 0, 0, tolower(expression_token_value))
+        expression_literal_type[expression] = "bool"
+        expression_lex_next()
+    } else if (expression_token_type == "literal_null") {
+        expression = expression_new("literal", 0, 0, "")
+        expression_literal_type[expression] = "null"
+        expression_lex_next()
+    } else if (expression_token_type == "left_parenthesis") {
+        expression_lex_next()
+        expression = expression_parse_pipe()
+        expression_expect("right_parenthesis")
+    } else if (expression_token_type == "identifier") {
+        name = tolower(expression_token_value)
+        expression_lex_next()
+        if (name == "select" || name == "has") {
+            expression_expect("left_parenthesis")
+            argument = expression_parse_pipe()
+            expression_expect("right_parenthesis")
+            expression = expression_new(name, argument, 0, "")
+        } else if (name == "length" || name == "keys" || name == "kind" || name == "type") {
+            if (expression_token_type == "left_parenthesis") {
+                expression_lex_next()
+                expression_expect("right_parenthesis")
             }
-            item_index = query_segment_value[i]
-            if (item_index < 0 || item_index >= sequence_count[resolved]) {
-                fail("query index out of range: " item_index)
+            expression = expression_new(name, 0, 0, "")
+        } else {
+            fail("unknown expression operator: " name)
+        }
+    } else {
+        fail("expected expression but found " expression_token_name(expression_token_type))
+    }
+
+    while (1) {
+        if (expression_token_type == "dot") {
+            expression_lex_next()
+            if (!expression_token_is_key()) {
+                fail("expected a key after .")
             }
-            node = sequence_child[resolved, item_index + 1]
+            expression = expression_new("key", expression, 0, expression_token_value)
+            expression_lex_next()
+        } else if (expression_token_type == "left_bracket") {
+            expression_lex_next()
+            if (expression_token_type == "right_bracket") {
+                expression = expression_new("each", expression, 0, "")
+                expression_lex_next()
+            } else if (expression_token_type == "number") {
+                if (expression_token_value !~ /^[0-9]+$/) {
+                    fail("sequence indexes must be non-negative integers")
+                }
+                step = expression_token_value + 0
+                expression_lex_next()
+                expression_expect("right_bracket")
+                expression = expression_new("index", expression, 0, step)
+            } else if (expression_token_type == "string") {
+                step = expression_token_value
+                expression_lex_next()
+                expression_expect("right_bracket")
+                expression = expression_new("key", expression, 0, step)
+            } else {
+                fail("brackets require an index, quoted key, or empty iterator")
+            }
+        } else {
+            break
         }
     }
-    return node
+    return expression
+}
+
+function expression_parse_unary(    operand) {
+    if (expression_token_type == "not") {
+        expression_lex_next()
+        operand = expression_new("identity", 0, 0, "")
+        return expression_new("not", operand, 0, "")
+    }
+    return expression_parse_primary()
+}
+
+function expression_parse_compare(    left, operator, right) {
+    left = expression_parse_unary()
+    while (expression_token_type == "compare") {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_unary()
+        left = expression_new("compare", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_and(    left, right) {
+    left = expression_parse_compare()
+    while (expression_token_type == "and") {
+        expression_lex_next()
+        right = expression_parse_compare()
+        left = expression_new("and", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_or(    left, right) {
+    left = expression_parse_and()
+    while (expression_token_type == "or") {
+        expression_lex_next()
+        right = expression_parse_and()
+        left = expression_new("or", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_alternative(    left, right) {
+    left = expression_parse_or()
+    while (expression_token_type == "alternative") {
+        expression_lex_next()
+        right = expression_parse_or()
+        left = expression_new("alternative", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_pipe(    left, right) {
+    left = expression_parse_alternative()
+    while (expression_token_type == "pipe") {
+        expression_lex_next()
+        right = expression_parse_alternative()
+        left = expression_new("pipe", left, right, "")
+    }
+    return left
+}
+
+function expression_parse(source,    expression) {
+    expression_source = source
+    expression_position = 1
+    expression_count = 0
+    expression_lex_next()
+    expression = expression_parse_pipe()
+    if (expression_token_type != "end") {
+        fail("unexpected token after expression: " expression_token_name(expression_token_type))
+    }
+    return expression
 }
 
 function collect_keys_from_source(source, collection,    resolved, i) {
@@ -1081,6 +1302,347 @@ function collect_mapping_keys(mapping, collection,    stack_key, seen_key, i, ke
         }
     }
     delete collection_stack[stack_key]
+}
+
+function expression_stream_new() {
+    return ++expression_stream_serial
+}
+
+function expression_stream_push(stream, node) {
+    expression_stream_node[stream, ++expression_stream_count[stream]] = node
+}
+
+function expression_stream_single(node,    stream) {
+    stream = expression_stream_new()
+    expression_stream_push(stream, node)
+    return stream
+}
+
+function expression_stream_append(target, source,    i) {
+    for (i = 1; i <= expression_stream_count[source]; i++) {
+        expression_stream_push(target, expression_stream_node[source, i])
+    }
+}
+
+function expression_scalar(value, value_type) {
+    return new_node("scalar", 0, value, value_type, "")
+}
+
+function expression_boolean(value) {
+    if (value) {
+        return expression_scalar("true", "bool")
+    }
+    return expression_scalar("false", "bool")
+}
+
+function expression_null() {
+    return expression_scalar("", "null")
+}
+
+function expression_truthy(node,    resolved, lowered) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "scalar") {
+        return 1
+    }
+    if (node_type[resolved] == "null") {
+        return 0
+    }
+    if (node_type[resolved] == "bool") {
+        lowered = tolower(node_value[resolved])
+        return lowered != "false"
+    }
+    return 1
+}
+
+function expression_numeric(node,    resolved, value) {
+    resolved = resolve_alias(node)
+    if (node_type[resolved] == "int") {
+        return json_integer(node_value[resolved]) + 0
+    }
+    value = node_value[resolved]
+    gsub(/_/, "", value)
+    if (tolower(value) ~ /\.(inf|nan)$/) {
+        fail("non-finite numbers cannot be compared")
+    }
+    return value + 0
+}
+
+function expression_nodes_equal(left, right,    left_node, right_node) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "scalar" || node_kind[right_node] != "scalar") {
+        return 0
+    }
+    if (node_type[left_node] == "null" || node_type[right_node] == "null") {
+        return node_type[left_node] == "null" && node_type[right_node] == "null"
+    }
+    if ((node_type[left_node] == "int" || node_type[left_node] == "float") &&
+        (node_type[right_node] == "int" || node_type[right_node] == "float")) {
+        return expression_numeric(left_node) == expression_numeric(right_node)
+    }
+    if (node_type[left_node] == "bool" && node_type[right_node] == "bool") {
+        return tolower(node_value[left_node]) == tolower(node_value[right_node])
+    }
+    return node_value[left_node] == node_value[right_node]
+}
+
+function expression_compare(left, right, operator,    left_node, right_node, left_value, right_value, equal) {
+    equal = expression_nodes_equal(left, right)
+    if (operator == "==") {
+        return equal
+    }
+    if (operator == "!=") {
+        return !equal
+    }
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "scalar" || node_kind[right_node] != "scalar") {
+        fail("ordering comparisons require scalar values")
+    }
+    if ((node_type[left_node] == "int" || node_type[left_node] == "float") &&
+        (node_type[right_node] == "int" || node_type[right_node] == "float")) {
+        left_value = expression_numeric(left_node)
+        right_value = expression_numeric(right_node)
+    } else if (node_type[left_node] == "string" && node_type[right_node] == "string") {
+        left_value = node_value[left_node]
+        right_value = node_value[right_node]
+    } else {
+        fail("ordering comparisons require two numbers or two strings")
+    }
+    if (operator == ">") {
+        return left_value > right_value
+    }
+    if (operator == ">=") {
+        return left_value >= right_value
+    }
+    if (operator == "<") {
+        return left_value < right_value
+    }
+    return left_value <= right_value
+}
+
+function expression_mapping_length(node,    collection) {
+    collection = ++collection_serial
+    collect_mapping_keys(node, collection)
+    return collection_count[collection]
+}
+
+function expression_kind_name(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] == "mapping") {
+        return "map"
+    }
+    if (node_kind[resolved] == "sequence") {
+        return "seq"
+    }
+    return "scalar"
+}
+
+function expression_type_name(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_tag[resolved] != "") {
+        if (node_tag[resolved] ~ /^tag:yaml.org,2002:/) {
+            return "!!" substr(node_tag[resolved], length("tag:yaml.org,2002:") + 1)
+        }
+        return node_tag[resolved]
+    }
+    if (node_kind[resolved] == "mapping") {
+        return "!!map"
+    }
+    if (node_kind[resolved] == "sequence") {
+        return "!!seq"
+    }
+    if (node_type[resolved] == "string") {
+        return "!!str"
+    }
+    if (node_type[resolved] == "tagged") {
+        return "!"
+    }
+    return "!!" node_type[resolved]
+}
+
+function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
+    output = expression_stream_new()
+    kind = expression_kind[expression]
+
+    if (kind == "identity") {
+        expression_stream_append(output, input)
+        return output
+    }
+    if (kind == "literal") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "pipe") {
+        middle = expression_evaluate(expression_left[expression], input)
+        return expression_evaluate(expression_right[expression], middle)
+    }
+    if (kind == "key" || kind == "index" || kind == "each") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = expression_stream_node[middle, i]
+            resolved = resolve_alias(node)
+            if (kind == "key") {
+                if (node_kind[resolved] == "mapping") {
+                    child = mapping_lookup(resolved, expression_value[expression])
+                } else {
+                    child = 0
+                }
+                expression_stream_push(output, child ? child : expression_null())
+            } else if (kind == "index") {
+                if (node_kind[resolved] == "sequence" && expression_value[expression] < sequence_count[resolved]) {
+                    child = sequence_child[resolved, expression_value[expression] + 1]
+                } else {
+                    child = 0
+                }
+                expression_stream_push(output, child ? child : expression_null())
+            } else if (node_kind[resolved] == "sequence") {
+                for (j = 1; j <= sequence_count[resolved]; j++) {
+                    expression_stream_push(output, sequence_child[resolved, j])
+                }
+            } else if (node_kind[resolved] == "mapping") {
+                collection = ++collection_serial
+                collect_mapping_keys(resolved, collection)
+                for (j = 1; j <= collection_count[collection]; j++) {
+                    key = collection_key[collection, j]
+                    expression_stream_push(output, mapping_lookup(resolved, key))
+                }
+            } else {
+                if (node_kind[resolved] == "scalar") {
+                    fail("cannot iterate over " node_type[resolved])
+                }
+                fail("cannot iterate over " node_kind[resolved])
+            }
+        }
+        return output
+    }
+    if (kind == "select") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            single = expression_stream_single(node)
+            predicate = expression_evaluate(expression_left[expression], single)
+            matched = 0
+            for (j = 1; j <= expression_stream_count[predicate]; j++) {
+                if (expression_truthy(expression_stream_node[predicate, j])) {
+                    matched = 1
+                    break
+                }
+            }
+            if (matched) {
+                expression_stream_push(output, node)
+            }
+        }
+        return output
+    }
+    if (kind == "compare" || kind == "and" || kind == "or") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                for (collection = 1; collection <= expression_stream_count[right_stream]; collection++) {
+                    node = expression_stream_node[left_stream, j]
+                    child = expression_stream_node[right_stream, collection]
+                    if (kind == "compare") {
+                        matched = expression_compare(node, child, expression_value[expression])
+                    } else if (kind == "and") {
+                        matched = expression_truthy(node) && expression_truthy(child)
+                    } else {
+                        matched = expression_truthy(node) || expression_truthy(child)
+                    }
+                    expression_stream_push(output, expression_boolean(matched))
+                }
+            }
+        }
+        return output
+    }
+    if (kind == "not") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            expression_stream_push(output, expression_boolean(!expression_truthy(expression_stream_node[middle, i])))
+        }
+        return output
+    }
+    if (kind == "alternative") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            matched = 0
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                node = expression_stream_node[left_stream, j]
+                if (expression_truthy(node)) {
+                    expression_stream_push(output, node)
+                    matched = 1
+                }
+            }
+            if (!matched) {
+                right_stream = expression_evaluate(expression_right[expression], single)
+                expression_stream_append(output, right_stream)
+            }
+        }
+        return output
+    }
+    if (kind == "length" || kind == "keys" || kind == "kind" || kind == "type" || kind == "has") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            resolved = resolve_alias(node)
+            if (kind == "length") {
+                if (node_kind[resolved] == "mapping") {
+                    matched = expression_mapping_length(resolved)
+                } else if (node_kind[resolved] == "sequence") {
+                    matched = sequence_count[resolved]
+                } else if (node_type[resolved] == "null") {
+                    matched = 0
+                } else {
+                    matched = length(node_value[resolved])
+                }
+                expression_stream_push(output, expression_scalar(matched "", "int"))
+            } else if (kind == "kind") {
+                expression_stream_push(output, expression_scalar(expression_kind_name(resolved), "string"))
+            } else if (kind == "type") {
+                expression_stream_push(output, expression_scalar(expression_type_name(resolved), "string"))
+            } else if (kind == "keys") {
+                result_node = new_node("sequence", 0, "", "", "")
+                if (node_kind[resolved] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(resolved, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        add_sequence(result_node, expression_scalar(collection_key[collection, j], "string"), 0)
+                    }
+                } else if (node_kind[resolved] == "sequence") {
+                    for (j = 0; j < sequence_count[resolved]; j++) {
+                        add_sequence(result_node, expression_scalar(j "", "int"), 0)
+                    }
+                } else {
+                    fail("keys requires a mapping or sequence")
+                }
+                expression_stream_push(output, result_node)
+            } else {
+                single = expression_stream_single(node)
+                argument_stream = expression_evaluate(expression_left[expression], single)
+                if (expression_stream_count[argument_stream] < 1) {
+                    expression_stream_push(output, expression_boolean(0))
+                    continue
+                }
+                argument = resolve_alias(expression_stream_node[argument_stream, 1])
+                if (node_kind[argument] != "scalar") {
+                    fail("has requires a scalar key or index")
+                }
+                if (node_kind[resolved] == "mapping") {
+                    matched = mapping_lookup(resolved, node_value[argument]) != 0
+                } else if (node_kind[resolved] == "sequence" && node_type[argument] == "int") {
+                    matched = (node_value[argument] + 0) >= 0 && (node_value[argument] + 0) < sequence_count[resolved]
+                } else {
+                    matched = 0
+                }
+                expression_stream_push(output, expression_boolean(matched))
+            }
+        }
+        return output
+    }
+    fail("cannot evaluate expression kind " kind)
 }
 
 function base_integer(value, base,    result, i, char, digit) {
@@ -1271,23 +1833,8 @@ function output_events(document) {
     print "STREAM_END"
 }
 
-function output_result(document, query, output_mode,    root, target, resolved) {
-    if (!(document in document_root)) {
-        fail("document index not found: " document)
-    }
-    if (output_mode == "ast") {
-        output_ast(document)
-        return
-    }
-    if (output_mode == "events") {
-        output_events(document)
-        return
-    }
-
-    root = document_root[document]
-    target = query_node(root, query)
+function output_expression_node(target, output_mode,    resolved) {
     resolved = resolve_alias(target)
-
     if (output_mode == "line") {
         print node_line[target]
     } else if (output_mode == "type") {
@@ -1306,6 +1853,28 @@ function output_result(document, query, output_mode,    root, target, resolved) 
     } else {
         emit_json(target)
         printf "\n"
+    }
+}
+
+function output_result(document, query, output_mode,    root, expression, input, results, i) {
+    if (!(document in document_root)) {
+        fail("document index not found: " document)
+    }
+    if (output_mode == "ast") {
+        output_ast(document)
+        return
+    }
+    if (output_mode == "events") {
+        output_events(document)
+        return
+    }
+
+    root = document_root[document]
+    expression = expression_parse(query)
+    input = expression_stream_single(root)
+    results = expression_evaluate(expression, input)
+    for (i = 1; i <= expression_stream_count[results]; i++) {
+        output_expression_node(expression_stream_node[results, i], output_mode)
     }
 }
 
@@ -1367,7 +1936,9 @@ Usage:
 
 Examples:
   ysh ".server.host" config.yml
-  ysh ".services[0]" config.yml --json
+  ysh ".services[] | select(.enabled) | .name" config.yml
+  ysh ".services | length" config.yml
+  ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
   printf "%s\\n" "answer: 42" | ysh ".answer"
 
@@ -1388,8 +1959,9 @@ Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY uses yq-style paths such as .server.host, .items[0], and
-.["key.with.dots"]. Collections are emitted as JSON by default.
+QUERY supports yq-style paths, [], pipes, select, comparisons, boolean
+operators, // defaults, length, keys, has, kind, and type. Collections
+are emitted as JSON by default; streams emit one result per line.
 EOF
 }
 
@@ -1539,16 +2111,20 @@ ysh_main() {
                 YSH_INPUT_FILE=$YSH_POSITIONAL_ONE
                 YSH_QUERY=$YSH_POSITIONAL_TWO
             else
-                ysh_error "query must start with ."
-                return 2
+                YSH_QUERY=$YSH_POSITIONAL_ONE
+                YSH_INPUT_FILE=$YSH_POSITIONAL_TWO
             fi
             ;;
         esac
     elif [ "$YSH_POSITIONAL_COUNT" -eq 1 ]; then
-        case "$YSH_POSITIONAL_ONE" in
-        .*) YSH_QUERY=$YSH_POSITIONAL_ONE ;;
-        *) YSH_INPUT_FILE=$YSH_POSITIONAL_ONE ;;
-        esac
+        if [ -f "$YSH_POSITIONAL_ONE" ] || [ "$YSH_POSITIONAL_ONE" = "-" ]; then
+            YSH_INPUT_FILE=$YSH_POSITIONAL_ONE
+        else
+            case "$YSH_POSITIONAL_ONE" in
+            *.yml|*.yaml|*.json) YSH_INPUT_FILE=$YSH_POSITIONAL_ONE ;;
+            *) YSH_QUERY=$YSH_POSITIONAL_ONE ;;
+            esac
+        fi
     fi
 
     if [ -n "$YSH_INPUT_FILE" ] && [ "$YSH_INPUT_FILE" != "-" ] && [ ! -f "$YSH_INPUT_FILE" ]; then


### PR DESCRIPTION
## What changed

- replace single-node path evaluation with streams of node references
- add `[]` iteration, pipes, `select`, comparisons, boolean operators, and `//` defaults
- add `length`, `keys`, `has`, `kind`, and yq-compatible `type`
- make missing keys and indexes produce null so defaults compose like yq
- emit multiple results one per line
- rebuild the README, website, docs, installer, and changelog for v1.1.0

## Why

Version 1 created the graph needed for a real expression engine. Version 1.1 begins using it: operators pass node identities rather than copied scalar text, preserving types, tags, source lines, aliases, and merged mappings through a pipeline.

## Compatibility and checks

- `make all` — 47 behavioral tests pass
- ShellCheck and POSIX shell syntax pass
- 25 representative supported expressions match yq v4.53.3 byte-for-byte in JSON mode
- CI covers Ubuntu AWK, macOS AWK, BusyBox AWK, and `/bin/sh`

## Boundary

This release is intentionally read-only. Mutation and YAML emission are reserved for the v1.2 transformation release.