### PR TITLE
YAML.sh v1.2: writable transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to YAML.sh are documented here.
 
+## [1.2.0] - 2026-08-01
+
+Version 1.2 turns the expression stream into a writable graph and adds a semantic YAML emitter. YAML.sh can now construct, transform, and safely rewrite documents while keeping its one-file `/bin/sh` + AWK runtime.
+
+### Added
+
+- Recursive descent with `..` and optional traversal with `?`.
+- Array and object construction, including streamed values inside array literals.
+- Arithmetic with `+`, `-`, `*`, `/`, and `%`; `+` also concatenates strings and sequences, shallow-merges mappings, and treats null as an identity value.
+- Direct assignment with `=`, relative update with `|=`, and compound `+=`, `-=`, `*=`, `/=`, and `%=` updates.
+- Missing mapping-path creation, multi-node streamed assignments, and `del(...)` for mappings and sequences.
+- Semantic YAML output through `-y` and `-o=yaml`, with valid document separators for multi-result streams.
+- Null-input construction with `-n` and permission-preserving in-place file updates with `-i`.
+- Transformation, round-trip, arithmetic, error, and in-place coverage, bringing the behavioral suite to 57 tests.
+
+### Changed
+
+- Assignment binds before a following pipe, matching yq transformation flow such as `.value = 2 | .value`.
+- Help, README, website, and docs now distinguish semantic YAML preservation from presentation preservation.
+- The generated YAML emitter uses deterministic block collections and quoted string/key output.
+
+### Known boundaries
+
+- YAML emission does not preserve comments, blank lines, original scalar quoting, flow-vs-block style, directive spelling, or exact presentation.
+- Variables, interpolation, regexes, reducers, dynamic keys, slices, deep-merge operators, style/comment operators, file operators, and yq's non-YAML codecs are not implemented.
+- Aliases are shared graph references. Updating through an alias or inherited merge key may update its anchor or merge source.
+- In-place mode requires a real single-document file, rejects multi-document streams before replacement, and uses the POSIX `cp` and `rm` utilities in addition to the normal `/bin/sh` + AWK runtime.
+
 ## [1.1.0] - 2026-08-01
 
 Version 1.1 moves beyond exact paths with a read-only expression engine modeled on the highest-value parts of yq.
@@ -113,6 +141,7 @@ Version 1 is a ground-up, intentionally breaking rebuild around a real YAML node
 
 - Report missing files and make the help flag exit successfully.
 
+[1.2.0]: https://github.com/azohra/yaml.sh/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/azohra/yaml.sh/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/azohra/yaml.sh/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/azohra/yaml.sh/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v1.1.0" src="https://img.shields.io/badge/release-v1.1.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
+  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v1.2.0" src="https://img.shields.io/badge/release-v1.2.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
   <a href="https://github.com/azohra/yaml.sh/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/azohra/yaml.sh/ci.yml?style=for-the-badge&label=tests&labelColor=101410"></a>
   <img alt="POSIX shell plus AWK" src="https://img.shields.io/badge/runtime-sh_+_awk-f5f1e8?style=for-the-badge&labelColor=101410">
 </p>
@@ -35,6 +35,8 @@ $ ysh -o=json '.services[0]' config.yml
 $ ysh '.services[] | select(.enabled) | .name' config.yml
 api
 web
+
+$ ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
 ```
 
 ## The tiny idea
@@ -44,7 +46,7 @@ Sometimes `yq` is exactly the right answer. Sometimes you are writing the script
 YAML.sh lives in that second moment. Version 1 stopped pretending YAML was flattened text and built a real node graph instead:
 
 ```text
-YAML stream → node graph → aliases + merges → expression stream → values
+YAML stream → node graph → aliases + merges → expression stream → values / YAML
 ```
 
 Mappings stay mappings. Empty sequences survive. Aliases retain identity. Keys containing dots no longer turn into existential crises.
@@ -52,7 +54,7 @@ Mappings stay mappings. Empty sequences survive. Aliases retain identity. Keys c
 ## Install one file
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -95,7 +97,7 @@ ysh '.services[0]' config.yml
 # {"name":"api","enabled":true}
 ```
 
-Then let v1.1 stream and filter real nodes:
+Then let the expression engine stream and filter real nodes:
 
 ```sh
 ysh '.services[] | select(.enabled) | .name' config.yml
@@ -106,6 +108,37 @@ ysh '.services | length' config.yml
 
 ysh '.missing // "fallback"' config.yml
 # fallback
+```
+
+## Make it change things
+
+Version 1.2 gives those node references teeth. Assign values, build missing paths, update relative to the current value, or delete a node:
+
+```sh
+ysh -o=yaml '.release.channel = "stable"' config.yml
+ysh -o=yaml '.replicas += 1' config.yml
+ysh -o=yaml 'del(.metadata.internal)' config.yml
+```
+
+Ready to commit to the bit?
+
+```sh
+ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
+```
+
+`-i` requires a real single-document file, writes valid YAML only after the full parse and transformation succeeds, and preserves the existing file permissions. It intentionally normalizes presentation: comments, blank lines, scalar style, and key quoting are not retained. Multi-document streams remain queryable but are rejected by `-i` in v1.2 so unselected documents can never be silently dropped.
+
+Construct a fresh document without reading input:
+
+```sh
+ysh -n -o=yaml '{name: "api", enabled: true, ports: [8080, 8443]}'
+```
+
+And yes, AWK is now doing arithmetic too:
+
+```sh
+ysh -n --json '2 + 3 * 4'
+# 14
 ```
 
 Pipe YAML in naturally:
@@ -133,7 +166,7 @@ ysh '.metadata["build[number]"]' config.yml
 | Partial merge handling | Alias lists, flow mappings, and block merge sequences |
 | Parser internals hidden | `--ast` and `--events` on tap |
 
-Version 1.1 adds `[]`, pipes, `select`, comparisons, booleans, defaults, and collection helpers without changing the node graph. The original v1 CLI break remains intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
+Version 1.1 added streaming reads. Version 1.2 adds recursive and optional traversal, construction, arithmetic, assignments, deletion, YAML output, null input, and in-place editing without changing the one-file runtime. The original v1 CLI break remains intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
 
 ## Open the hood
 
@@ -159,15 +192,18 @@ ysh --document 1 '.project.name' stream.yml
 | Flag | Purpose |
 | --- | --- |
 | `QUERY [FILE]` | Query a file or standard input. |
-| `-o, --output FORMAT` | Select `value`, `raw`, or `json`. |
+| `-o, --output FORMAT` | Select `value`, `raw`, `json`, or `yaml`. |
 | `-r, --raw-output` | Print scalar text without JSON quoting. |
 | `--json` | Emit JSON. |
+| `-y, --yaml-output` | Emit YAML. |
 | `--type` | Print the selected node type. |
 | `--tag` | Print its expanded tag. |
 | `--line` | Print its source line. |
 | `--ast` | Print the node graph. |
 | `--events` | Print parser-style events. |
 | `-d, --document N` | Select a zero-based document. |
+| `-n, --null-input` | Build output without reading input. |
+| `-i, --inplace` | Transform and replace one YAML file. |
 | `-V, --version` | Print the installed version. |
 | `-h, --help` | Print help. |
 
@@ -187,7 +223,7 @@ That contract is the promise: supported syntax gets a test; neighboring unsuppor
 make all
 ```
 
-That rebuilds the standalone `ysh`, runs ShellCheck, and executes 47 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
+That rebuilds the standalone `ysh`, runs ShellCheck, and executes 57 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
 
 The constraint is the fun part. Come make AWK do something unreasonable.
 

--- a/_static/_www/docs/README.md
+++ b/_static/_www/docs/README.md
@@ -14,13 +14,15 @@ ysh -o=json '.services[0]' config.yml
 ysh '.services[] | select(.enabled) | .name' config.yml
 # api
 # web
+
+ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
 ```
 
 ## Why it exists
 
 Sometimes `yq` is exactly the right answer. Sometimes you are writing the script that would install `yq`.
 
-YAML.sh aims for the useful middle: familiar yq-style paths, streams and filters; serious handling of common YAML structures; one auditable file; and no additional packages. It does not pretend that YAML is simple or claim complete specification compliance.
+YAML.sh aims for the useful middle: familiar yq-style paths, streams, filters, construction, and updates; serious handling of common YAML structures; one auditable file; and no additional packages. It does not pretend that YAML is simple or claim complete specification compliance.
 
 ## What changed in v1
 
@@ -33,7 +35,7 @@ YAML.sh aims for the useful middle: familiar yq-style paths, streams and filters
 | Tag syntax mostly discarded | Expanded tags attached to nodes |
 | Inline merge subset | Alias lists, flow mappings, and block merge sequences |
 
-Version 1.1 adds iteration, pipes, selection, comparisons, booleans, defaults, and collection helpers above that graph.
+Version 1.1 added iteration, pipes, selection, comparisons, booleans, defaults, and collection helpers above that graph. Version 1.2 makes references writable and adds recursive and optional traversal, arithmetic, construction, assignment, deletion, YAML output, and in-place updates.
 
 ## Pick a path
 

--- a/_static/_www/docs/development.md
+++ b/_static/_www/docs/development.md
@@ -15,7 +15,7 @@ src/ysh.sh              POSIX shell CLI
 src/ysh.awk             YAML engine
 test/test.sh            behavioral suite
 test/advanced.yml       v1 conformance fixture
-test/expressions.yml    v1.1 expression fixture
+test/expressions.yml    v1 expression and transformation fixture
 _static/_www            unified Cloudflare Pages site
 _static/_www/docs       documentation
 _static/_www/install    installer

--- a/_static/_www/docs/getting-started.md
+++ b/_static/_www/docs/getting-started.md
@@ -5,7 +5,7 @@ YAML.sh ships as one executable text file. The released file contains both the p
 ## Install the pinned release
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -77,6 +77,20 @@ ysh '.release.channel // "stable"' config.yml
 # stable
 ```
 
+Transform and emit YAML:
+
+```sh
+ysh -o=yaml '.release.channel = "stable"' config.yml
+```
+
+Once the result looks right, update the file in place:
+
+```sh
+ysh -i '.release.channel = "stable"' config.yml
+```
+
+In-place output preserves the file permissions but normalizes YAML presentation. Comments and original formatting are not retained, so review the diff like the tiny chaos engineer you are.
+
 ## Standard input
 
 Omit the file to read YAML from standard input:
@@ -93,6 +107,6 @@ generate-config | ysh '.release.version' -
 
 ## Next steps
 
-- [Learn paths, streams, filters, and defaults](queries.md)
-- [Choose JSON, type, tag, or line output](output.md)
+- [Learn paths, streams, construction, and updates](queries.md)
+- [Choose value, JSON, YAML, type, tag, or line output](output.md)
 - [Read the YAML support contract](supported_yml.md)

--- a/_static/_www/docs/index.html
+++ b/_static/_www/docs/index.html
@@ -11,7 +11,7 @@
   <link rel="canonical" href="https://yaml.azohra.com/docs/">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-  <link rel="stylesheet" href="theme.css?v=1.1.0">
+  <link rel="stylesheet" href="theme.css?v=1.2.0">
   <title>YAML.sh v1 docs</title>
 </head>
 <body>

--- a/_static/_www/docs/internals.md
+++ b/_static/_www/docs/internals.md
@@ -15,12 +15,12 @@ expression parser
     ↓
 node-stream evaluator
     ↓
-raw / JSON / type / tag / line / AST / events
+value / JSON / YAML / type / tag / line / AST / events
 ```
 
 ## The shell layer
 
-The `/bin/sh` launcher handles arguments, input selection, document selection, and output mode. It passes the YAML stream and expression to the embedded AWK program.
+The `/bin/sh` launcher handles arguments, input selection, document selection, output mode, null input, and safe in-place replacement. It passes the YAML stream and expression to the embedded AWK program.
 
 The development sources remain separate:
 
@@ -53,9 +53,11 @@ Merge entries remain marked edges in the graph. Lookup checks explicit entries f
 
 ## Expression streams
 
-The v1.1 expression parser builds a small operator tree with explicit precedence for pipes, alternatives, booleans, and comparisons. Evaluation passes numbered streams of node references between operators. `[]` can expand one collection into many references; `select` tests each reference while returning the original node when its predicate succeeds.
+The expression parser builds a small operator tree with explicit precedence for pipes, assignment, alternatives, booleans, comparisons, arithmetic, and traversal. Evaluation passes numbered streams of node references between operators. `[]` and `..` can expand one node into many references; `select` tests each reference while returning the original node when its predicate succeeds.
 
-Because streams contain node IDs rather than copied values, type, tag, source line, alias identity, parentage, and merge behavior survive a pipeline. Computed booleans, strings, numbers, and key lists are represented as temporary graph nodes and use the same output path as parsed YAML.
+Because streams contain node IDs rather than copied values, type, tag, source line, alias identity, parentage, and merge behavior survive a pipeline. Assignments replace the selected graph nodes; missing mapping paths use attachable placeholders. Computed booleans, strings, numbers, constructed collections, and key lists are represented as temporary graph nodes and use the same output path as parsed YAML.
+
+The YAML emitter walks that graph directly. It preserves semantic structure and graph properties where possible, while deliberately normalizing presentation into a stable quoted block style.
 
 ## Diagnostics
 

--- a/_static/_www/docs/migration.md
+++ b/_static/_www/docs/migration.md
@@ -66,7 +66,8 @@ The following v0.x flags are not accepted in v1:
 - `-f`, because the input file is positional.
 - `-T`, because the transpiled representation is gone.
 - `-q` and `-Q`, because the positional query replaces them.
-- `-s`, `-l`, `-L`, `-c`, `-i`, and `-I`, because node selection uses one query grammar.
+- `-s`, `-l`, `-L`, `-c`, and `-I`, because node selection uses one query grammar.
+- The v0.x meaning of `-i`. Version 1.2 reuses `-i` for yq-style in-place file updates.
 - `--next`, because `--document N` addresses a document directly.
 
 If a script depends on v0.x behavior, pin `v0.4.0` while migrating.

--- a/_static/_www/docs/output.md
+++ b/_static/_www/docs/output.md
@@ -1,6 +1,6 @@
 # Output & metadata
 
-The same query can return a value, JSON, a node type, its expanded tag, or its source line.
+The same query can return a value, JSON, YAML, a node type, its expanded tag, or its source line.
 
 ## Default value output
 
@@ -35,6 +35,20 @@ ysh -o=json '.service' config.yml
 ```
 
 Recognized nulls, booleans, integers, and finite floats become native JSON values. Strings, timestamps, and application-tagged scalars are JSON strings. Non-finite YAML floats are quoted because JSON has no equivalent value.
+
+## YAML
+
+Use `-y`, `-o=yaml`, or `--output-format=yaml` to serialize selected or transformed nodes:
+
+```sh
+ysh -o=yaml '.release.channel = "stable"' config.yml
+```
+
+Multiple results are separated with `---`, producing a valid YAML stream. Anchors, aliases, tags, and merge edges are emitted when they still exist in the selected graph.
+
+The emitter is semantic, not presentation-preserving. It deliberately uses a stable block layout and quotes string values and ordinary mapping keys. Comments, blank lines, original quote choices, flow-vs-block style, directive spelling, and exact scalar formatting are not retained.
+
+`-i` always uses this YAML emitter. It parses and transforms into a sibling temporary file first, copies the successful result over the requested file, and preserves the destination's existing permission bits. Version 1.2 rejects multi-document in-place updates before replacement so an unselected document cannot be lost.
 
 ## Type
 

--- a/_static/_www/docs/queries.md
+++ b/_static/_www/docs/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-Version 1.1 evaluates a focused, read-only yq-style expression language over streams of node references. Paths still select exact nodes; iteration and pipes let one input become many results without flattening the YAML graph.
+Version 1.2 evaluates a focused yq-style expression language over streams of writable node references. Paths select exact nodes; iteration and pipes let one input become many results; assignments change the graph those references belong to.
 
 ## Paths
 
@@ -43,6 +43,18 @@ ysh '.services[] | .name' config.yml
 
 Streams print one scalar or compact JSON collection per line.
 
+## Recursive and optional traversal
+
+`..` walks the current node and all of its descendants. Add `?` to a path or iterator when a missing value or incompatible type should produce no result instead of null or an error:
+
+```sh
+ysh '.. | select(has("name")) | .name' config.yml
+ysh '.metadata.owner[]?' config.yml
+ysh '.possibly_missing?' config.yml
+```
+
+Recursive descent follows resolved aliases and merge keys once per node, so shared graph nodes are not repeated forever.
+
 ## Select
 
 `select(EXPRESSION)` keeps the current node when its predicate is truthy:
@@ -54,9 +66,9 @@ ysh '.services[] | select(.port >= 8000) | .name' config.yml
 
 Null and false are falsey. Every other scalar and collection is truthy.
 
-## Comparisons and booleans
+## Comparisons, booleans, and arithmetic
 
-Version 1.1 supports:
+The expression language supports:
 
 - Equality: `==` and `!=`.
 - Ordering: `>`, `>=`, `<`, and `<=` for two numbers or two strings.
@@ -68,6 +80,14 @@ ysh '.services[] | .enabled | not' config.yml
 ```
 
 Numeric comparisons normalize integers and finite floats. Like yq, equality comparisons operate on scalar values rather than treating whole collections as identical values.
+
+Arithmetic uses normal precedence with `+`, `-`, `*`, `/`, and `%`. `+` also concatenates strings and sequences, shallow-merges mappings, and treats null as an identity value.
+
+```sh
+ysh '.replicas + 1' config.yml
+ysh -n --json '2 + 3 * 4'
+ysh -n --json '[1, 2] + [3]'
+```
 
 ## Defaults
 
@@ -98,12 +118,45 @@ Filters can begin an expression when they operate on the root:
 ysh 'length' config.yml
 ```
 
+## Construct values
+
+Array and object literals can collect results from the current input. Unquoted identifier keys are accepted as a friendly extension; quoted keys work too.
+
+```sh
+ysh --json '[.services[].name]' config.yml
+ysh --json '{owner: .metadata.owner, count: (.services | length)}' config.yml
+ysh -n -o=yaml '{name: "api", enabled: true}'
+```
+
+`-n` supplies one null input without reading standard input, which makes it useful for creating a new document.
+
+## Assign and delete
+
+`=` evaluates its right side against the original input. `|=` evaluates it relative to each selected node. Missing mapping paths are created as needed.
+
+```sh
+ysh -o=yaml '.release.channel = "stable"' config.yml
+ysh -o=yaml '.services[].enabled |= not' config.yml
+ysh -o=yaml '.services[0].port += 20' config.yml
+ysh -o=yaml 'del(.metadata.internal)' config.yml
+```
+
+The compound forms `+=`, `-=`, `*=`, `/=`, and `%=` are relative arithmetic updates. Parenthesized streamed selections can update several nodes:
+
+```sh
+ysh -o=yaml '(.services[] | select(.enabled) | .tier) = "active"' config.yml
+```
+
+Use `-i` to replace a real single-document input file after a successful transform. In-place mode always emits YAML, cannot be combined with standard input or `-n`, and rejects multi-document streams in v1.2.
+
 ## Merged and aliased nodes
 
 Expressions follow aliases and mapping merge sources automatically. Explicit entries override merged entries; in a merge sequence, the first source containing a key wins.
 
+Aliases are genuine shared graph references. Updating through an alias or an inherited merge value therefore updates the referenced source node too. Use construction to materialize an independent value when shared identity is not what you want.
+
 ## Current expression boundary
 
-Version 1.1 is deliberately read-only. It does not yet implement recursive descent, optional traversal, arithmetic, string interpolation, variables, construction, assignment, deletion, YAML serialization, or in-place editing.
+This is a useful yq-shaped language, not the complete yq language. Version 1.2 does not implement variables, string interpolation, regular expressions, dynamic object keys, slices, reduce/ireduce, sort/group/unique operators, file operators, date operators, XML/CSV/TOML codecs, style/comment operators, or yq's full deep-merge and cross-document semantics.
 
-Those features require a writable reference evaluator and a YAML emitter. They can now be added above the same node-stream architecture without replacing the parser.
+Supported transformations are tested against their expected graph behavior. For automation that needs arbitrary yq programs, use yq; YAML.sh is for the delightfully constrained machine where installing yq is the problem you are trying to solve.

--- a/_static/_www/docs/supported_yml.md
+++ b/_static/_www/docs/supported_yml.md
@@ -67,12 +67,14 @@ YAML version directives are validated but do not switch between complete YAML 1.
 - Flow collections must fit on one line.
 - The complete YAML Unicode escape repertoire and every block-folding edge case are not implemented.
 - Full YAML 1.1/1.2 schema resolution and application-specific construction are not implemented.
-- The expression language is read-only. It does not yet provide recursive descent, optional traversal, arithmetic, variables, construction, assignments, deletion, YAML serialization, or in-place updates.
+- YAML emission preserves data, node kinds, tags, anchors, aliases, and merge edges where representable, but not comments or original presentation style.
+- Updating through an alias or inherited merge value follows shared node identity and can change the anchor or merge source.
+- The expression language does not implement variables, interpolation, regular expressions, reducers, dynamic keys, slices, deep-merge operators, comment/style operators, file operators, or yq's non-YAML codecs.
 
 YAML.sh does not evaluate YAML as shell code, but it is not a complete specification validator. Use a maintained full YAML library when exact conformance for arbitrary or hostile input is a hard requirement.
 
 ## Conformance fixture
 
-The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. The expression fixture covers node streams, iteration, pipes, filters, comparisons, booleans, defaults, and collection helpers. Rejection tests cover every limitation that could otherwise be misread as supported syntax.
+The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. The expression fixture covers node streams, iteration, pipes, filters, comparisons, booleans, defaults, construction, arithmetic, recursive and optional traversal, assignment, deletion, YAML round-tripping, null input, and in-place updates. Rejection tests cover boundaries that could otherwise be misread as supported syntax.
 
 See [`test/advanced.yml`](https://github.com/azohra/yaml.sh/blob/main/test/advanced.yml) and [`test/test.sh`](https://github.com/azohra/yaml.sh/blob/main/test/test.sh).

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -12,14 +12,14 @@
   <meta property="og:image" content="https://yaml.azohra.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="YAML.sh v1.1 — yq energy, zero baggage">
+  <meta property="og:image:alt" content="YAML.sh v1.2 — yq energy, zero baggage">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="YAML.sh v1 — yq energy. zero baggage.">
   <meta name="twitter:description" content="A yq-like YAML query tool in one portable shell script.">
   <meta name="twitter:image" content="https://yaml.azohra.com/og.png">
   <link rel="canonical" href="https://yaml.azohra.com">
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" href="css/style.css?v=1.1.0">
+  <link rel="stylesheet" href="css/style.css?v=1.2.0">
   <title>YAML.sh v1 — yq energy. zero baggage.</title>
 </head>
 <body>
@@ -41,7 +41,7 @@
   <main id="main">
     <section class="hero section-shell">
       <div class="hero-copy">
-        <p class="eyebrow"><span class="status-dot"></span> Version 1.1 · now the nodes can flow</p>
+        <p class="eyebrow"><span class="status-dot"></span> Version 1.2 · the tiny parser writes back</p>
         <h1>yq energy.<br><span>zero baggage.</span></h1>
         <p class="hero-lede">Query YAML with one portable shell script. No package manager. No language runtime. No mystery binary. Just <code>/bin/sh</code>, AWK, and a surprising amount of ambition.</p>
         <div class="hero-actions">
@@ -51,7 +51,7 @@
         <ul class="hero-facts" aria-label="YAML.sh highlights">
           <li><strong>1</strong> file</li>
           <li><strong>0</strong> extra packages</li>
-          <li><strong>47</strong> behavioral tests</li>
+          <li><strong>57</strong> behavioral tests</li>
         </ul>
       </div>
 
@@ -85,6 +85,7 @@
 
     <section class="ticker" aria-label="Core capabilities">
       <div>
+        <span>QUERY + UPDATE</span><b>◆</b>
         <span>PIPES + SELECT</span><b>◆</b>
         <span>ANCHORS + ALIASES</span><b>◆</b>
         <span>MERGE KEYS</span><b>◆</b>
@@ -116,7 +117,7 @@
         <article>
           <span class="step">03</span>
           <h3>Query</h3>
-          <p>Paths, iteration, pipes, filters, comparisons, and defaults stream real node references without flattening them.</p>
+          <p>Paths, filters, construction, arithmetic, and assignments operate on real node references without flattening them.</p>
         </article>
       </div>
     </section>
@@ -130,7 +131,7 @@
         <div class="demo-tabs" role="tablist" aria-label="CLI examples">
           <button id="tab-query" role="tab" aria-selected="true" aria-controls="panel-query" data-demo="query">Query</button>
           <button id="tab-json" role="tab" aria-selected="false" aria-controls="panel-json" data-demo="json">JSON</button>
-          <button id="tab-merge" role="tab" aria-selected="false" aria-controls="panel-merge" data-demo="merge">Merge</button>
+          <button id="tab-merge" role="tab" aria-selected="false" aria-controls="panel-merge" data-demo="merge">Update</button>
           <button id="tab-inspect" role="tab" aria-selected="false" aria-controls="panel-inspect" data-demo="inspect">Inspect</button>
         </div>
         <div class="demo-panel" id="panel-query" role="tabpanel" aria-labelledby="tab-query">
@@ -145,9 +146,13 @@ web</code></pre>
 {"name":"api","enabled":true,"port":8080}</code></pre>
         </div>
         <div class="demo-panel" id="panel-merge" role="tabpanel" aria-labelledby="tab-merge" hidden>
-          <p class="demo-label">Aliases and merge precedence resolve before querying.</p>
-          <pre><code><span class="prompt">$</span> ysh '.production.retries' config.yml
-3</code></pre>
+          <p class="demo-label">Change a real file in place—no temporary runtime required.</p>
+          <pre><code><span class="prompt">$</span> ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
+
+<span class="prompt">$</span> ysh '.services[].tier' config.yml
+active
+backend
+active</code></pre>
         </div>
         <div class="demo-panel" id="panel-inspect" role="tabpanel" aria-labelledby="tab-inspect" hidden>
           <p class="demo-label">Open the hood whenever the YAML gets weird.</p>
@@ -199,7 +204,7 @@ node  1  mapping  line=1</code></pre>
         <p>The installer downloads a pinned release and places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
       </div>
       <div class="install-command">
-        <div class="install-command-label"><span>Terminal</span><span>v1.1.0</span></div>
+        <div class="install-command-label"><span>Terminal</span><span>v1.2.0</span></div>
         <pre><code id="install-code">curl -fsSL https://yaml.azohra.com/install | sh</code></pre>
         <button class="copy-button" type="button" data-copy="install-code"><span>Copy command</span><b aria-hidden="true">⌘</b></button>
         <p class="install-note">Prefer to inspect first? <a href="/install">Read the installer source.</a></p>

--- a/_static/_www/install
+++ b/_static/_www/install
@@ -5,6 +5,6 @@ install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.1.0/ysh -o "${temporary_file}"
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o "${temporary_file}"
 mkdir -p "${install_dir}"
 install -m 755 "${temporary_file}" "${install_dir}/ysh"

--- a/src/ysh.awk
+++ b/src/ysh.awk
@@ -973,6 +973,24 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position += 2
         return
     }
+    if (char next_char == "..") {
+        expression_token_type = "recursive"
+        expression_token_value = ".."
+        expression_position += 2
+        return
+    }
+    if (char next_char == "|=") {
+        expression_token_type = "update"
+        expression_token_value = "|="
+        expression_position += 2
+        return
+    }
+    if ((char == "+" || char == "-" || char == "*" || char == "/" || char == "%") && next_char == "=") {
+        expression_token_type = "compound"
+        expression_token_value = char next_char
+        expression_position += 2
+        return
+    }
     if (char next_char == "==" || char next_char == "!=" || char next_char == ">=" || char next_char == "<=") {
         expression_token_type = "compare"
         expression_token_value = char next_char
@@ -981,6 +999,12 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
     }
     if (char == ">" || char == "<") {
         expression_token_type = "compare"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "=") {
+        expression_token_type = "assign"
         expression_token_value = char
         expression_position++
         return
@@ -1027,6 +1051,36 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position++
         return
     }
+    if (char == "{") {
+        expression_token_type = "left_brace"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "}") {
+        expression_token_type = "right_brace"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ":") {
+        expression_token_type = "colon"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "?") {
+        expression_token_type = "question"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "+" || char == "-" || char == "*" || char == "/" || char == "%") {
+        expression_token_type = "arithmetic"
+        expression_token_value = char
+        expression_position++
+        return
+    }
 
     quote = sprintf("%c", 39)
     if (char == "\"" || char == quote) {
@@ -1051,11 +1105,25 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         fail("unterminated string in expression")
     }
 
-    if (char ~ /^[0-9]$/ || (char == "-" && next_char ~ /^[0-9]$/)) {
+    if (char ~ /^[0-9]$/) {
         start = expression_position
-        expression_position++
-        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9.eE_+-]$/) {
+        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
             expression_position++
+        }
+        if (substr(expression_source, expression_position, 1) == "." && substr(expression_source, expression_position + 1, 1) ~ /^[0-9]$/) {
+            expression_position++
+            while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
+                expression_position++
+            }
+        }
+        if (tolower(substr(expression_source, expression_position, 1)) == "e") {
+            expression_position++
+            if (substr(expression_source, expression_position, 1) == "+" || substr(expression_source, expression_position, 1) == "-") {
+                expression_position++
+            }
+            while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
+                expression_position++
+            }
         }
         expression_token_type = "number"
         expression_token_value = substr(expression_source, start, expression_position - start)
@@ -1099,7 +1167,7 @@ function expression_expect(type,    actual) {
     expression_lex_next()
 }
 
-function expression_parse_primary(    expression, name, step, argument, value, value_type) {
+function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key) {
     if (expression_token_type == "dot") {
         expression = expression_new("identity", 0, 0, "")
         expression_lex_next()
@@ -1107,6 +1175,9 @@ function expression_parse_primary(    expression, name, step, argument, value, v
             expression = expression_new("key", expression, 0, expression_token_value)
             expression_lex_next()
         }
+    } else if (expression_token_type == "recursive") {
+        expression = expression_new("recursive", 0, 0, "")
+        expression_lex_next()
     } else if (expression_token_type == "string") {
         expression = expression_new("literal", 0, 0, expression_token_value)
         expression_literal_type[expression] = "string"
@@ -1132,10 +1203,45 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         expression_lex_next()
         expression = expression_parse_pipe()
         expression_expect("right_parenthesis")
+    } else if (expression_token_type == "left_bracket") {
+        expression = expression_new("array", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_type != "right_bracket") {
+            while (1) {
+                child = expression_parse_pipe()
+                expression_child[expression, ++expression_child_count[expression]] = child
+                if (expression_token_type != "comma") {
+                    break
+                }
+                expression_lex_next()
+            }
+        }
+        expression_expect("right_bracket")
+    } else if (expression_token_type == "left_brace") {
+        expression = expression_new("object", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_type != "right_brace") {
+            while (1) {
+                if (expression_token_type != "identifier" && expression_token_type != "string") {
+                    fail("object keys must be identifiers or strings")
+                }
+                key = expression_token_value
+                expression_lex_next()
+                expression_expect("colon")
+                child = expression_parse_pipe()
+                expression_object_key[expression, ++expression_child_count[expression]] = key
+                expression_child[expression, expression_child_count[expression]] = child
+                if (expression_token_type != "comma") {
+                    break
+                }
+                expression_lex_next()
+            }
+        }
+        expression_expect("right_brace")
     } else if (expression_token_type == "identifier") {
         name = tolower(expression_token_value)
         expression_lex_next()
-        if (name == "select" || name == "has") {
+        if (name == "select" || name == "has" || name == "del") {
             expression_expect("left_parenthesis")
             argument = expression_parse_pipe()
             expression_expect("right_parenthesis")
@@ -1153,6 +1259,10 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         fail("expected expression but found " expression_token_name(expression_token_type))
     }
 
+    if (expression_token_type == "question") {
+        expression_optional[expression] = 1
+        expression_lex_next()
+    }
     while (1) {
         if (expression_token_type == "dot") {
             expression_lex_next()
@@ -1185,6 +1295,10 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         } else {
             break
         }
+        if (expression_token_type == "question") {
+            expression_optional[expression] = 1
+            expression_lex_next()
+        }
     }
     return expression
 }
@@ -1195,15 +1309,42 @@ function expression_parse_unary(    operand) {
         operand = expression_new("identity", 0, 0, "")
         return expression_new("not", operand, 0, "")
     }
+    if (expression_token_type == "arithmetic" && expression_token_value == "-") {
+        expression_lex_next()
+        operand = expression_parse_unary()
+        return expression_new("negate", operand, 0, "")
+    }
     return expression_parse_primary()
 }
 
-function expression_parse_compare(    left, operator, right) {
+function expression_parse_product(    left, operator, right) {
     left = expression_parse_unary()
-    while (expression_token_type == "compare") {
+    while (expression_token_type == "arithmetic" && (expression_token_value == "*" || expression_token_value == "/" || expression_token_value == "%")) {
         operator = expression_token_value
         expression_lex_next()
         right = expression_parse_unary()
+        left = expression_new("arithmetic", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_sum(    left, operator, right) {
+    left = expression_parse_product()
+    while (expression_token_type == "arithmetic" && (expression_token_value == "+" || expression_token_value == "-")) {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_product()
+        left = expression_new("arithmetic", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_compare(    left, operator, right) {
+    left = expression_parse_sum()
+    while (expression_token_type == "compare") {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_sum()
         left = expression_new("compare", left, right, operator)
     }
     return left
@@ -1239,11 +1380,28 @@ function expression_parse_alternative(    left, right) {
     return left
 }
 
-function expression_parse_pipe(    left, right) {
+function expression_parse_assignment(    left, right, kind, operator, identity, arithmetic) {
     left = expression_parse_alternative()
+    if (expression_token_type == "assign" || expression_token_type == "update" || expression_token_type == "compound") {
+        kind = expression_token_type
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_assignment()
+        if (kind == "compound") {
+            identity = expression_new("identity", 0, 0, "")
+            arithmetic = expression_new("arithmetic", identity, right, substr(operator, 1, 1))
+            return expression_new("update", left, arithmetic, "")
+        }
+        return expression_new(kind, left, right, "")
+    }
+    return left
+}
+
+function expression_parse_pipe(    left, right) {
+    left = expression_parse_assignment()
     while (expression_token_type == "pipe") {
         expression_lex_next()
-        right = expression_parse_alternative()
+        right = expression_parse_assignment()
         left = expression_new("pipe", left, right, "")
     }
     return left
@@ -1455,6 +1613,244 @@ function expression_type_name(node,    resolved) {
     return "!!" node_type[resolved]
 }
 
+function expression_clone_node(source,    resolved, clone, i, collection, key, child) {
+    resolved = resolve_alias(source)
+    clone = new_node(node_kind[resolved], 0, node_value[resolved], node_type[resolved], node_tag[resolved])
+    if (node_kind[resolved] == "sequence") {
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            add_sequence(clone, expression_clone_node(sequence_child[resolved, i]), 0)
+        }
+    } else if (node_kind[resolved] == "mapping") {
+        collection = ++collection_serial
+        collect_mapping_keys(resolved, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            child = mapping_lookup(resolved, key)
+            add_mapping(clone, key, expression_clone_node(child), 0, 0)
+        }
+    }
+    return clone
+}
+
+function expression_clear_node(node,    i, key) {
+    if (node_kind[node] == "mapping") {
+        for (i = 1; i <= mapping_count[node]; i++) {
+            key = mapping_key[node, i]
+            delete mapping_seen[node SUBSEP key]
+            delete mapping_key[node, i]
+            delete mapping_child[node, i]
+            delete mapping_merge[node, i]
+        }
+        mapping_count[node] = 0
+    } else if (node_kind[node] == "sequence") {
+        for (i = 1; i <= sequence_count[node]; i++) {
+            delete sequence_child[node, i]
+        }
+        sequence_count[node] = 0
+    }
+    delete alias_target[node]
+    delete node_anchor[node]
+}
+
+function expression_attach_missing(node,    parent, key) {
+    if (!(node in expression_missing_parent) || expression_placeholder_attached[node]) {
+        return
+    }
+    parent = expression_missing_parent[node]
+    key = expression_missing_key[node]
+    if (parent in expression_missing_parent) {
+        if (node_kind[parent] == "scalar" && node_type[parent] == "null") {
+            node_kind[parent] = "mapping"
+            node_type[parent] = ""
+            node_value[parent] = ""
+        }
+        expression_attach_missing(parent)
+    }
+    if (node_kind[parent] != "mapping") {
+        fail("cannot create key " key " below " expression_type_name(parent))
+    }
+    add_mapping(parent, key, node, 0, 0)
+    expression_placeholder_attached[node] = 1
+}
+
+function expression_replace_node(target, source,    clone, saved_parent, saved_edge, saved_line, saved_document, i, key, child) {
+    if (resolve_alias(target) == resolve_alias(source) && !(target in expression_missing_parent)) {
+        return target
+    }
+    clone = expression_clone_node(source)
+    saved_parent = node_parent[target]
+    saved_edge = node_parent_edge[target]
+    saved_line = node_line[target]
+    saved_document = node_document[target]
+    expression_clear_node(target)
+    node_kind[target] = node_kind[clone]
+    node_value[target] = node_value[clone]
+    node_type[target] = node_type[clone]
+    node_tag[target] = node_tag[clone]
+    node_line[target] = saved_line
+    node_document[target] = saved_document
+    node_parent[target] = saved_parent
+    node_parent_edge[target] = saved_edge
+    if (node_kind[clone] == "sequence") {
+        for (i = 1; i <= sequence_count[clone]; i++) {
+            child = sequence_child[clone, i]
+            add_sequence(target, child, 0)
+        }
+    } else if (node_kind[clone] == "mapping") {
+        for (i = 1; i <= mapping_count[clone]; i++) {
+            key = mapping_key[clone, i]
+            child = mapping_child[clone, i]
+            add_mapping(target, key, child, 0, mapping_merge[clone, i])
+        }
+    }
+    expression_attach_missing(target)
+    return target
+}
+
+function expression_delete_node(target,    parent, i, j, key, child) {
+    if (target in expression_missing_parent && !expression_placeholder_attached[target]) {
+        return
+    }
+    parent = node_parent[target]
+    if (!parent) {
+        expression_clear_node(target)
+        node_kind[target] = "scalar"
+        node_value[target] = ""
+        node_type[target] = "null"
+        node_tag[target] = ""
+        return
+    }
+    if (node_kind[parent] == "mapping") {
+        for (i = 1; i <= mapping_count[parent]; i++) {
+            if (mapping_child[parent, i] != target) {
+                continue
+            }
+            key = mapping_key[parent, i]
+            delete mapping_seen[parent SUBSEP key]
+            for (j = i; j < mapping_count[parent]; j++) {
+                mapping_key[parent, j] = mapping_key[parent, j + 1]
+                mapping_child[parent, j] = mapping_child[parent, j + 1]
+                mapping_merge[parent, j] = mapping_merge[parent, j + 1]
+                child = mapping_child[parent, j]
+                node_parent_edge[child] = "key " mapping_key[parent, j]
+            }
+            delete mapping_key[parent, mapping_count[parent]]
+            delete mapping_child[parent, mapping_count[parent]]
+            delete mapping_merge[parent, mapping_count[parent]]
+            mapping_count[parent]--
+            return
+        }
+    } else if (node_kind[parent] == "sequence") {
+        for (i = 1; i <= sequence_count[parent]; i++) {
+            if (sequence_child[parent, i] != target) {
+                continue
+            }
+            for (j = i; j < sequence_count[parent]; j++) {
+                sequence_child[parent, j] = sequence_child[parent, j + 1]
+                child = sequence_child[parent, j]
+                node_parent_edge[child] = "index " (j - 1)
+            }
+            delete sequence_child[parent, sequence_count[parent]]
+            sequence_count[parent]--
+            return
+        }
+    }
+}
+
+function expression_collect_recursive(node, stream, serial,    resolved, seen_key, i, collection, key) {
+    resolved = resolve_alias(node)
+    seen_key = serial SUBSEP resolved
+    if (seen_key in expression_recursive_seen) {
+        return
+    }
+    expression_recursive_seen[seen_key] = 1
+    expression_stream_push(stream, resolved)
+    if (node_kind[resolved] == "sequence") {
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            expression_collect_recursive(sequence_child[resolved, i], stream, serial)
+        }
+    } else if (node_kind[resolved] == "mapping") {
+        collection = ++collection_serial
+        collect_mapping_keys(resolved, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            expression_collect_recursive(mapping_lookup(resolved, key), stream, serial)
+        }
+    }
+}
+
+function expression_arithmetic_number(value, value_type, operator,    rendered) {
+    rendered = sprintf("%.15g", value)
+    if (value_type == "float" && rendered !~ /[.eE]/) {
+        rendered = rendered ".0"
+    }
+    return expression_scalar(rendered, value_type)
+}
+
+function expression_arithmetic(left, right, operator,    left_node, right_node, left_type, right_type, result_type, value, result, i, collection, key, child) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    left_type = node_type[left_node]
+    right_type = node_type[right_node]
+
+    if (operator == "+" && left_type == "null") {
+        return expression_clone_node(right_node)
+    }
+    if (operator == "+" && right_type == "null") {
+        return expression_clone_node(left_node)
+    }
+    if ((left_type == "int" || left_type == "float") && (right_type == "int" || right_type == "float")) {
+        if (operator == "/" && expression_numeric(right_node) == 0) {
+            fail("division by zero")
+        }
+        if (operator == "%" && expression_numeric(right_node) == 0) {
+            fail("modulo by zero")
+        }
+        if (operator == "+") {
+            value = expression_numeric(left_node) + expression_numeric(right_node)
+        } else if (operator == "-") {
+            value = expression_numeric(left_node) - expression_numeric(right_node)
+        } else if (operator == "*") {
+            value = expression_numeric(left_node) * expression_numeric(right_node)
+        } else if (operator == "/") {
+            value = expression_numeric(left_node) / expression_numeric(right_node)
+        } else {
+            value = expression_numeric(left_node) % expression_numeric(right_node)
+        }
+        result_type = (operator == "/" || left_type == "float" || right_type == "float") ? "float" : "int"
+        return expression_arithmetic_number(value, result_type, operator)
+    }
+    if (operator == "+" && left_type == "string" && right_type == "string") {
+        return expression_scalar(node_value[left_node] node_value[right_node], "string")
+    }
+    if (operator == "+" && node_kind[left_node] == "sequence" && node_kind[right_node] == "sequence") {
+        result = new_node("sequence", 0, "", "", "")
+        for (i = 1; i <= sequence_count[left_node]; i++) {
+            add_sequence(result, expression_clone_node(sequence_child[left_node, i]), 0)
+        }
+        for (i = 1; i <= sequence_count[right_node]; i++) {
+            add_sequence(result, expression_clone_node(sequence_child[right_node, i]), 0)
+        }
+        return result
+    }
+    if (operator == "+" && node_kind[left_node] == "mapping" && node_kind[right_node] == "mapping") {
+        result = expression_clone_node(left_node)
+        collection = ++collection_serial
+        collect_mapping_keys(right_node, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            child = mapping_lookup(right_node, key)
+            if (mapping_lookup(result, key)) {
+                expression_replace_node(mapping_lookup(result, key), child)
+            } else {
+                add_mapping(result, key, expression_clone_node(child), 0, 0)
+            }
+        }
+        return result
+    }
+    fail("operator " operator " does not support " expression_type_name(left_node) " and " expression_type_name(right_node))
+}
+
 function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
     output = expression_stream_new()
     kind = expression_kind[expression]
@@ -1466,6 +1862,59 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
     if (kind == "literal") {
         for (i = 1; i <= expression_stream_count[input]; i++) {
             expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "array" || kind == "object") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            if (kind == "array") {
+                result_node = new_node("sequence", 0, "", "", "")
+                for (j = 1; j <= expression_child_count[expression]; j++) {
+                    middle = expression_evaluate(expression_child[expression, j], single)
+                    for (collection = 1; collection <= expression_stream_count[middle]; collection++) {
+                        add_sequence(result_node, expression_clone_node(expression_stream_node[middle, collection]), 0)
+                    }
+                }
+            } else {
+                result_node = new_node("mapping", 0, "", "", "")
+                for (j = 1; j <= expression_child_count[expression]; j++) {
+                    middle = expression_evaluate(expression_child[expression, j], single)
+                    child = expression_stream_count[middle] ? expression_stream_node[middle, 1] : expression_null()
+                    add_mapping(result_node, expression_object_key[expression, j], expression_clone_node(child), 0, 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "recursive") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_collect_recursive(expression_stream_node[input, i], output, ++expression_recursive_serial)
+        }
+        return output
+    }
+    if (kind == "negate") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = resolve_alias(expression_stream_node[middle, i])
+            if (node_type[node] != "int" && node_type[node] != "float") {
+                fail("unary - requires a number")
+            }
+            expression_stream_push(output, expression_arithmetic_number(-expression_numeric(node), node_type[node], "-"))
+        }
+        return output
+    }
+    if (kind == "arithmetic") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                for (collection = 1; collection <= expression_stream_count[right_stream]; collection++) {
+                    expression_stream_push(output, expression_arithmetic(expression_stream_node[left_stream, j], expression_stream_node[right_stream, collection], expression_value[expression]))
+                }
+            }
         }
         return output
     }
@@ -1484,14 +1933,25 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                 } else {
                     child = 0
                 }
-                expression_stream_push(output, child ? child : expression_null())
+                if (child) {
+                    expression_stream_push(output, child)
+                } else if (!expression_optional[expression]) {
+                    child = expression_null()
+                    expression_missing_parent[child] = resolved
+                    expression_missing_key[child] = expression_value[expression]
+                    expression_stream_push(output, child)
+                }
             } else if (kind == "index") {
                 if (node_kind[resolved] == "sequence" && expression_value[expression] < sequence_count[resolved]) {
                     child = sequence_child[resolved, expression_value[expression] + 1]
                 } else {
                     child = 0
                 }
-                expression_stream_push(output, child ? child : expression_null())
+                if (child) {
+                    expression_stream_push(output, child)
+                } else if (!expression_optional[expression]) {
+                    expression_stream_push(output, expression_null())
+                }
             } else if (node_kind[resolved] == "sequence") {
                 for (j = 1; j <= sequence_count[resolved]; j++) {
                     expression_stream_push(output, sequence_child[resolved, j])
@@ -1504,12 +1964,46 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                     expression_stream_push(output, mapping_lookup(resolved, key))
                 }
             } else {
+                if (expression_optional[expression]) {
+                    continue
+                }
                 if (node_kind[resolved] == "scalar") {
                     fail("cannot iterate over " node_type[resolved])
                 }
                 fail("cannot iterate over " node_kind[resolved])
             }
         }
+        return output
+    }
+    if (kind == "assign" || kind == "update") {
+        left_stream = expression_evaluate(expression_left[expression], input)
+        if (kind == "assign") {
+            right_stream = expression_evaluate(expression_right[expression], input)
+            if (!expression_stream_count[right_stream]) {
+                expression_stream_push(right_stream, expression_null())
+            }
+            for (i = 1; i <= expression_stream_count[left_stream]; i++) {
+                j = expression_stream_count[right_stream] == expression_stream_count[left_stream] ? i : 1
+                expression_replace_node(expression_stream_node[left_stream, i], expression_stream_node[right_stream, j])
+            }
+        } else {
+            for (i = 1; i <= expression_stream_count[left_stream]; i++) {
+                node = expression_stream_node[left_stream, i]
+                single = expression_stream_single(node)
+                right_stream = expression_evaluate(expression_right[expression], single)
+                child = expression_stream_count[right_stream] ? expression_stream_node[right_stream, 1] : expression_null()
+                expression_replace_node(node, child)
+            }
+        }
+        expression_stream_append(output, input)
+        return output
+    }
+    if (kind == "del") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = expression_stream_count[middle]; i >= 1; i--) {
+            expression_delete_node(expression_stream_node[middle, i])
+        }
+        expression_stream_append(output, input)
         return output
     }
     if (kind == "select") {
@@ -1752,6 +2246,129 @@ function emit_json(node,    resolved, stack_key, i, collection, key, child, lowe
     delete json_stack[stack_key]
 }
 
+function yaml_spaces(indent,    result, i) {
+    result = ""
+    for (i = 0; i < indent; i++) {
+        result = result " "
+    }
+    return result
+}
+
+function yaml_properties(node,    result, tag) {
+    result = ""
+    tag = node_tag[node]
+    if (tag != "") {
+        if (tag ~ /^tag:yaml.org,2002:/) {
+            tag = "!!" substr(tag, length("tag:yaml.org,2002:") + 1)
+        } else {
+            tag = "!<" tag ">"
+        }
+        result = tag
+    }
+    if (node_anchor[node] != "") {
+        if (result != "") {
+            result = result " "
+        }
+        result = result "&" node_anchor[node]
+    }
+    return result
+}
+
+function yaml_scalar_text(node,    value, properties, lowered) {
+    if (node_kind[node] == "alias") {
+        return "*" node_value[node]
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        properties = properties " "
+    }
+    value = node_value[node]
+    if (node_type[node] == "null") {
+        return properties "null"
+    }
+    if (node_type[node] == "bool") {
+        lowered = tolower(value)
+        if (lowered == "true" || lowered == "false") {
+            return properties lowered
+        }
+    }
+    if (node_type[node] == "int" || node_type[node] == "float" || node_type[node] == "timestamp") {
+        return properties value
+    }
+    return properties json_quote(value)
+}
+
+function yaml_inline_node(node,    properties) {
+    if (node_kind[node] == "scalar" || node_kind[node] == "alias") {
+        return yaml_scalar_text(node)
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        properties = properties " "
+    }
+    if (node_kind[node] == "mapping" && mapping_count[node] == 0) {
+        return properties "{}"
+    }
+    if (node_kind[node] == "sequence" && sequence_count[node] == 0) {
+        return properties "[]"
+    }
+    return ""
+}
+
+function emit_yaml_collection(node, indent,    i, child, inline, properties, key) {
+    if (node_kind[node] == "mapping") {
+        for (i = 1; i <= mapping_count[node]; i++) {
+            key = mapping_key[node, i]
+            if (mapping_merge[node, i]) {
+                printf "%s<<:", yaml_spaces(indent)
+            } else {
+                printf "%s%s:", yaml_spaces(indent), json_quote(key)
+            }
+            child = mapping_child[node, i]
+            inline = yaml_inline_node(child)
+            if (inline != "") {
+                printf " %s\n", inline
+            } else {
+                properties = yaml_properties(child)
+                if (properties != "") {
+                    printf " %s", properties
+                }
+                printf "\n"
+                emit_yaml_collection(child, indent + 2)
+            }
+        }
+        return
+    }
+    for (i = 1; i <= sequence_count[node]; i++) {
+        child = sequence_child[node, i]
+        printf "%s-", yaml_spaces(indent)
+        inline = yaml_inline_node(child)
+        if (inline != "") {
+            printf " %s\n", inline
+        } else {
+            properties = yaml_properties(child)
+            if (properties != "") {
+                printf " %s", properties
+            }
+            printf "\n"
+            emit_yaml_collection(child, indent + 2)
+        }
+    }
+}
+
+function emit_yaml(node,    inline, properties) {
+    inline = yaml_inline_node(node)
+    if (inline != "") {
+        print inline
+        return
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        print properties
+    }
+    emit_yaml_collection(node, 0)
+}
+
 function output_ast(document,    node, i) {
     for (node = 1; node <= node_count; node++) {
         if (node_document[node] != document) {
@@ -1842,6 +2459,8 @@ function output_expression_node(target, output_mode,    resolved) {
     } else if (output_mode == "json") {
         emit_json(target)
         printf "\n"
+    } else if (output_mode == "yaml") {
+        emit_yaml(target)
     } else if (node_kind[resolved] == "scalar") {
         print node_value[resolved]
     } else {
@@ -1868,6 +2487,9 @@ function output_result(document, query, output_mode,    root, expression, input,
     input = expression_stream_single(root)
     results = expression_evaluate(expression, input)
     for (i = 1; i <= expression_stream_count[results]; i++) {
+        if (output_mode == "yaml" && i > 1) {
+            print "---"
+        }
         output_expression_node(expression_stream_node[results, i], output_mode)
     }
 }
@@ -1909,7 +2531,19 @@ END {
         finalize_nodes()
         validate_aliases()
         validate_merges()
-        output_result(selected_document + 0, query, output_mode)
+        if (inplace_mode) {
+            document_total = 0
+            for (document_number in document_root) {
+                document_total++
+            }
+            if (document_total > 1) {
+                print "Error: --inplace does not yet support multi-document streams" > "/dev/stderr"
+                exit_status = 1
+            }
+        }
+        if (!exit_status) {
+            output_result(selected_document + 0, query, output_mode)
+        }
     }
     exit exit_status
 }

--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.1.0
+YSH_VERSION=1.2.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER=$(cat src/ysh.awk)
@@ -21,15 +21,19 @@ Usage:
 Examples:
   ysh ".server.host" config.yml
   ysh ".services[] | select(.enabled) | .name" config.yml
+  ysh -o yaml '.release.channel = "stable"' config.yml
+  ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
+  ysh -n -o yaml '{name: "api", enabled: true}'
   ysh ".services | length" config.yml
   ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
   printf "%s\\n" "answer: 42" | ysh ".answer"
 
 Output:
-  -o, --output FORMAT      value, raw, or json
+  -o, --output FORMAT      value, raw, json, or yaml
   -r, --raw-output        print scalar values without JSON quoting
       --json              emit JSON
+  -y, --yaml-output       emit YAML
       --type              print the selected node type
       --tag               print the selected node tag
       --line              print the selected node source line
@@ -38,14 +42,17 @@ Output:
 
 Documents:
   -d, --document INDEX    select a zero-based YAML document
+  -n, --null-input        build output without reading input
+  -i, --inplace           update a YAML file in place
 
 Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY supports yq-style paths, [], pipes, select, comparisons, boolean
-operators, // defaults, length, keys, has, kind, and type. Collections
-are emitted as JSON by default; streams emit one result per line.
+QUERY supports yq-style paths, [], .., ?, pipes, select, comparisons,
+boolean operators, // defaults, construction, =, |=, del, length, keys,
+has, kind, and type. Collections are emitted as JSON by default; streams
+emit one result per line. In-place updates are serialized as YAML.
 EOF
 }
 
@@ -53,6 +60,7 @@ ysh_set_output_mode() {
     case "$1" in
     value|raw) YSH_OUTPUT_MODE="value" ;;
     json) YSH_OUTPUT_MODE="json" ;;
+    yaml|yml) YSH_OUTPUT_MODE="yaml" ;;
     *)
         ysh_error "unsupported output format: $1"
         return 2
@@ -61,20 +69,50 @@ ysh_set_output_mode() {
 }
 
 ysh_run_awk() {
-    if [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+    if [ "$YSH_NULL_INPUT" -eq 1 ]; then
         awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
+            "$YAML_AWK_PARSER" \
+            /dev/null
+    elif [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+        awk \
+            -v query="$YSH_QUERY" \
+            -v output_mode="$YSH_OUTPUT_MODE" \
+            -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER"
     else
         awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER" \
             "$YSH_INPUT_FILE"
     fi
+}
+
+ysh_run_inplace() {
+    YSH_TEMP_FILE=${YSH_INPUT_FILE}.ysh.$$
+    if ! (umask 077 && set -C && : > "$YSH_TEMP_FILE") 2>/dev/null; then
+        ysh_error "could not create temporary file beside: $YSH_INPUT_FILE"
+        return 1
+    fi
+    trap 'rm -f "$YSH_TEMP_FILE"' 0
+    trap 'exit 1' 1 2 3 15
+    YSH_OUTPUT_MODE=yaml
+    if ! ysh_run_awk > "$YSH_TEMP_FILE"; then
+        return 1
+    fi
+    if ! cp "$YSH_TEMP_FILE" "$YSH_INPUT_FILE"; then
+        ysh_error "could not replace input file: $YSH_INPUT_FILE"
+        return 1
+    fi
+    rm -f "$YSH_TEMP_FILE"
+    trap - 0 1 2 3 15
 }
 
 ysh_main() {
@@ -82,6 +120,8 @@ ysh_main() {
     YSH_DOCUMENT=0
     YSH_QUERY=.
     YSH_INPUT_FILE=
+    YSH_NULL_INPUT=0
+    YSH_INPLACE=0
     YSH_POSITIONAL_COUNT=0
     YSH_POSITIONAL_ONE=
     YSH_POSITIONAL_TWO=
@@ -108,6 +148,10 @@ ysh_main() {
             YSH_OUTPUT_MODE="json"
             shift
             ;;
+        -y|--yaml-output)
+            YSH_OUTPUT_MODE="yaml"
+            shift
+            ;;
         --type)
             YSH_OUTPUT_MODE="type"
             shift
@@ -126,6 +170,14 @@ ysh_main() {
             ;;
         --events)
             YSH_OUTPUT_MODE="events"
+            shift
+            ;;
+        -n|--null-input)
+            YSH_NULL_INPUT=1
+            shift
+            ;;
+        -i|--inplace|--in-place)
+            YSH_INPLACE=1
             shift
             ;;
         -d|--document)
@@ -214,6 +266,19 @@ ysh_main() {
     if [ -n "$YSH_INPUT_FILE" ] && [ "$YSH_INPUT_FILE" != "-" ] && [ ! -f "$YSH_INPUT_FILE" ]; then
         ysh_error "input file does not exist: $YSH_INPUT_FILE"
         return 1
+    fi
+
+    if [ "$YSH_INPLACE" -eq 1 ]; then
+        if [ "$YSH_NULL_INPUT" -eq 1 ]; then
+            ysh_error "--inplace cannot be combined with --null-input"
+            return 2
+        fi
+        if [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+            ysh_error "--inplace requires an input file"
+            return 2
+        fi
+        ysh_run_inplace
+        return $?
     fi
 
     ysh_run_awk

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 testVersion() {
-    assertEquals "v1.1.0" "$(./ysh --version)"
+    assertEquals "v1.2.0" "$(./ysh --version)"
 }
 
 testHelp() {
@@ -159,6 +159,80 @@ testExpressionJsonStreams() {
     assertEquals "$(printf '%s\n' '{"name":"api","enabled":true,"port":8080,"tier":"backend"}' '{"name":"web","enabled":true,"port":3000,"tier":"frontend"}')" "$(./ysh --json '.services[] | select(.enabled)' test/expressions.yml)"
 }
 
+testExpressionRecursiveAndOptionalTraversal() {
+    assertEquals "$(printf '%s\n' api worker web)" "$(./ysh '.. | select(has("name")) | .name' test/expressions.yml)"
+    assertEquals "" "$(./ysh '.metadata.owner[]?' test/expressions.yml)"
+    assertEquals "" "$(./ysh '.missing?' test/expressions.yml)"
+}
+
+testExpressionArrayAndObjectConstruction() {
+    assertEquals '["platform","api","worker","web"]' "$(./ysh --json '[.metadata.owner, .services[].name]' test/expressions.yml)"
+    assertEquals '{"owner":"platform","count":3}' "$(./ysh --json '{owner: .metadata.owner, count: (.services | length)}' test/expressions.yml)"
+    assertEquals '{"name":"api","enabled":true}' "$(./ysh -n --json '{name: "api", enabled: true}')"
+}
+
+testExpressionArithmetic() {
+    assertEquals "14" "$(./ysh -n --json '2 + 3 * 4')"
+    assertEquals "2.5" "$(./ysh -n --json '5 / 2')"
+    assertEquals '"yaml.sh"' "$(./ysh -n --json '"yaml" + ".sh"')"
+    assertEquals '[1,2,3]' "$(./ysh -n --json '[1, 2] + [3]')"
+    assertEquals '{"a":1,"b":3,"c":4}' "$(./ysh -n --json '{left: {a: 1, b: 2}, right: {b: 3, c: 4}} | .left + .right')"
+}
+
+testExpressionAssignmentAndCreation() {
+    assertEquals '{"owner":"core","region":"west"}' "$(./ysh --json '.metadata.owner = "core" | .metadata' test/expressions.yml)"
+    assertEquals '"stable"' "$(./ysh --json '.release.channel = "stable" | .release.channel' test/expressions.yml)"
+    assertEquals "$(printf '%s\n' active backend active)" "$(./ysh '(.services[] | select(.enabled) | .tier) = "active" | .services[].tier' test/expressions.yml)"
+}
+
+testExpressionRelativeAndCompoundUpdates() {
+    assertEquals "$(printf '%s\n' false true false)" "$(./ysh --json '.services[].enabled |= not | .services[].enabled' test/expressions.yml)"
+    assertEquals "8100" "$(./ysh --json '.services[0].port += 20 | .services[0].port' test/expressions.yml)"
+    assertEquals '"platform-team"' "$(./ysh --json '.metadata.owner += "-team" | .metadata.owner' test/expressions.yml)"
+}
+
+testExpressionDeletion() {
+    assertEquals '{"owner":"platform"}' "$(./ysh --json 'del(.metadata.region) | .metadata' test/expressions.yml)"
+    assertEquals "$(printf '%s\n' api web)" "$(./ysh 'del(.services[1]) | .services[].name' test/expressions.yml)"
+    assertEquals '{"owner":"platform","region":"west"}' "$(./ysh --json 'del(.missing) | .metadata' test/expressions.yml)"
+}
+
+testYamlOutputRoundTrips() {
+    assertEquals '"core"' "$(./ysh -o=yaml '.metadata.owner = "core"' test/expressions.yml | ./ysh --json '.metadata.owner')"
+    assertEquals '"web"' "$(./ysh -o=yaml '.' test/expressions.yml | ./ysh --json '.services[2].name')"
+    assertEquals '{"color":"red","size":"large","shape":"square"}' "$(./ysh -o=yaml '.' test/advanced.yml | ./ysh --json '.merged')"
+    assertEquals 'tag:example.com,2026:widget' "$(./ysh -o=yaml '.' test/advanced.yml | ./ysh --tag '.types.custom')"
+}
+
+testYamlOutputSeparatesStreams() {
+    assertEquals "$(printf '%s\n' '"api"' '---' '"worker"' '---' '"web"')" "$(./ysh -o=yaml '.services[].name' test/expressions.yml)"
+}
+
+testInplaceUpdate() {
+    inplace_file=test/.tmp-inplace-$$.yml
+    cp test/expressions.yml "$inplace_file"
+    chmod 640 "$inplace_file"
+    mode_before=$(find "$inplace_file" -prune -exec ls -ld {} \; | cut -c2-10)
+    ./ysh -i '.metadata.owner = "core"' "$inplace_file"
+    assertEquals 0 $?
+    assertEquals '"core"' "$(./ysh --json '.metadata.owner' "$inplace_file")"
+    assertEquals "$mode_before" "$(find "$inplace_file" -prune -exec ls -ld {} \; | cut -c2-10)"
+    rm -f "$inplace_file"
+}
+
+testInplaceRejectsMultiDocumentStreamsWithoutChanges() {
+    inplace_file=test/.tmp-inplace-multi-$$.yml
+    original_file=test/.tmp-inplace-original-$$.yml
+    cp test/test.yml "$inplace_file"
+    cp test/test.yml "$original_file"
+    result=$(./ysh -i '.key = "changed"' "$inplace_file" 2>&1)
+    assertNotEquals 0 $?
+    assertContains "$result" "does not yet support multi-document streams"
+    cmp "$original_file" "$inplace_file"
+    assertEquals 0 $?
+    rm -f "$inplace_file" "$original_file"
+}
+
 testExpressionErrors() {
     result=$(./ysh '.services[] | select(' test/expressions.yml 2>&1)
     assertNotEquals 0 $?
@@ -171,6 +245,10 @@ testExpressionErrors() {
     result=$(./ysh '.services | mystery' test/expressions.yml 2>&1)
     assertNotEquals 0 $?
     assertContains "$result" "unknown expression operator"
+
+    result=$(./ysh -n '1 / 0' 2>&1)
+    assertNotEquals 0 $?
+    assertContains "$result" "division by zero"
 }
 
 testScalarAndCollectionTypes() {
@@ -305,6 +383,10 @@ testCliErrors() {
     assertEquals 2 $?
     ./ysh --unknown ".key" test/test.yml >/dev/null 2>&1
     assertEquals 2 $?
+    ./ysh -i '.key = "value"' </dev/null >/dev/null 2>&1
+    assertEquals 2 $?
+    ./ysh -i -n '.key = "value"' test/test.yml >/dev/null 2>&1
+    assertEquals 2 $?
 }
 
 testRunsWithPosixShell() {
@@ -312,12 +394,12 @@ testRunsWithPosixShell() {
 }
 
 testReleaseArtifactsStayInSync() {
-    assertContains "$(cat README.md)" "v1.1.0/ysh"
-    assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.1.0/ysh"
-    assertContains "$(cat _static/_www/install)" "v1.1.0/ysh"
+    assertContains "$(cat README.md)" "v1.2.0/ysh"
+    assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.2.0/ysh"
+    assertContains "$(cat _static/_www/install)" "v1.2.0/ysh"
     assertContains "$(cat _static/_www/index.html)" "Install v1"
-    assertContains "$(cat _static/_www/index.html)" "style.css?v=1.1.0"
-    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.1.0"
+    assertContains "$(cat _static/_www/index.html)" "style.css?v=1.2.0"
+    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.2.0"
     assertContains "$(cat _static/_www/docs/index.html)" "docsify@4/lib/themes/vue.css"
     assertTrue "social preview image must exist" "[ -s _static/_www/og.png ]"
 }

--- a/ysh
+++ b/ysh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.1.0
+YSH_VERSION=1.2.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER='
@@ -979,6 +979,24 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position += 2
         return
     }
+    if (char next_char == "..") {
+        expression_token_type = "recursive"
+        expression_token_value = ".."
+        expression_position += 2
+        return
+    }
+    if (char next_char == "|=") {
+        expression_token_type = "update"
+        expression_token_value = "|="
+        expression_position += 2
+        return
+    }
+    if ((char == "+" || char == "-" || char == "*" || char == "/" || char == "%") && next_char == "=") {
+        expression_token_type = "compound"
+        expression_token_value = char next_char
+        expression_position += 2
+        return
+    }
     if (char next_char == "==" || char next_char == "!=" || char next_char == ">=" || char next_char == "<=") {
         expression_token_type = "compare"
         expression_token_value = char next_char
@@ -987,6 +1005,12 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
     }
     if (char == ">" || char == "<") {
         expression_token_type = "compare"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "=") {
+        expression_token_type = "assign"
         expression_token_value = char
         expression_position++
         return
@@ -1033,6 +1057,36 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position++
         return
     }
+    if (char == "{") {
+        expression_token_type = "left_brace"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "}") {
+        expression_token_type = "right_brace"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == ":") {
+        expression_token_type = "colon"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "?") {
+        expression_token_type = "question"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "+" || char == "-" || char == "*" || char == "/" || char == "%") {
+        expression_token_type = "arithmetic"
+        expression_token_value = char
+        expression_position++
+        return
+    }
 
     quote = sprintf("%c", 39)
     if (char == "\"" || char == quote) {
@@ -1057,11 +1111,25 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         fail("unterminated string in expression")
     }
 
-    if (char ~ /^[0-9]$/ || (char == "-" && next_char ~ /^[0-9]$/)) {
+    if (char ~ /^[0-9]$/) {
         start = expression_position
-        expression_position++
-        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9.eE_+-]$/) {
+        while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
             expression_position++
+        }
+        if (substr(expression_source, expression_position, 1) == "." && substr(expression_source, expression_position + 1, 1) ~ /^[0-9]$/) {
+            expression_position++
+            while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
+                expression_position++
+            }
+        }
+        if (tolower(substr(expression_source, expression_position, 1)) == "e") {
+            expression_position++
+            if (substr(expression_source, expression_position, 1) == "+" || substr(expression_source, expression_position, 1) == "-") {
+                expression_position++
+            }
+            while (expression_position <= length(expression_source) && substr(expression_source, expression_position, 1) ~ /^[0-9_]$/) {
+                expression_position++
+            }
         }
         expression_token_type = "number"
         expression_token_value = substr(expression_source, start, expression_position - start)
@@ -1105,7 +1173,7 @@ function expression_expect(type,    actual) {
     expression_lex_next()
 }
 
-function expression_parse_primary(    expression, name, step, argument, value, value_type) {
+function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key) {
     if (expression_token_type == "dot") {
         expression = expression_new("identity", 0, 0, "")
         expression_lex_next()
@@ -1113,6 +1181,9 @@ function expression_parse_primary(    expression, name, step, argument, value, v
             expression = expression_new("key", expression, 0, expression_token_value)
             expression_lex_next()
         }
+    } else if (expression_token_type == "recursive") {
+        expression = expression_new("recursive", 0, 0, "")
+        expression_lex_next()
     } else if (expression_token_type == "string") {
         expression = expression_new("literal", 0, 0, expression_token_value)
         expression_literal_type[expression] = "string"
@@ -1138,10 +1209,45 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         expression_lex_next()
         expression = expression_parse_pipe()
         expression_expect("right_parenthesis")
+    } else if (expression_token_type == "left_bracket") {
+        expression = expression_new("array", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_type != "right_bracket") {
+            while (1) {
+                child = expression_parse_pipe()
+                expression_child[expression, ++expression_child_count[expression]] = child
+                if (expression_token_type != "comma") {
+                    break
+                }
+                expression_lex_next()
+            }
+        }
+        expression_expect("right_bracket")
+    } else if (expression_token_type == "left_brace") {
+        expression = expression_new("object", 0, 0, "")
+        expression_lex_next()
+        if (expression_token_type != "right_brace") {
+            while (1) {
+                if (expression_token_type != "identifier" && expression_token_type != "string") {
+                    fail("object keys must be identifiers or strings")
+                }
+                key = expression_token_value
+                expression_lex_next()
+                expression_expect("colon")
+                child = expression_parse_pipe()
+                expression_object_key[expression, ++expression_child_count[expression]] = key
+                expression_child[expression, expression_child_count[expression]] = child
+                if (expression_token_type != "comma") {
+                    break
+                }
+                expression_lex_next()
+            }
+        }
+        expression_expect("right_brace")
     } else if (expression_token_type == "identifier") {
         name = tolower(expression_token_value)
         expression_lex_next()
-        if (name == "select" || name == "has") {
+        if (name == "select" || name == "has" || name == "del") {
             expression_expect("left_parenthesis")
             argument = expression_parse_pipe()
             expression_expect("right_parenthesis")
@@ -1159,6 +1265,10 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         fail("expected expression but found " expression_token_name(expression_token_type))
     }
 
+    if (expression_token_type == "question") {
+        expression_optional[expression] = 1
+        expression_lex_next()
+    }
     while (1) {
         if (expression_token_type == "dot") {
             expression_lex_next()
@@ -1191,6 +1301,10 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         } else {
             break
         }
+        if (expression_token_type == "question") {
+            expression_optional[expression] = 1
+            expression_lex_next()
+        }
     }
     return expression
 }
@@ -1201,15 +1315,42 @@ function expression_parse_unary(    operand) {
         operand = expression_new("identity", 0, 0, "")
         return expression_new("not", operand, 0, "")
     }
+    if (expression_token_type == "arithmetic" && expression_token_value == "-") {
+        expression_lex_next()
+        operand = expression_parse_unary()
+        return expression_new("negate", operand, 0, "")
+    }
     return expression_parse_primary()
 }
 
-function expression_parse_compare(    left, operator, right) {
+function expression_parse_product(    left, operator, right) {
     left = expression_parse_unary()
-    while (expression_token_type == "compare") {
+    while (expression_token_type == "arithmetic" && (expression_token_value == "*" || expression_token_value == "/" || expression_token_value == "%")) {
         operator = expression_token_value
         expression_lex_next()
         right = expression_parse_unary()
+        left = expression_new("arithmetic", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_sum(    left, operator, right) {
+    left = expression_parse_product()
+    while (expression_token_type == "arithmetic" && (expression_token_value == "+" || expression_token_value == "-")) {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_product()
+        left = expression_new("arithmetic", left, right, operator)
+    }
+    return left
+}
+
+function expression_parse_compare(    left, operator, right) {
+    left = expression_parse_sum()
+    while (expression_token_type == "compare") {
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_sum()
         left = expression_new("compare", left, right, operator)
     }
     return left
@@ -1245,11 +1386,28 @@ function expression_parse_alternative(    left, right) {
     return left
 }
 
-function expression_parse_pipe(    left, right) {
+function expression_parse_assignment(    left, right, kind, operator, identity, arithmetic) {
     left = expression_parse_alternative()
+    if (expression_token_type == "assign" || expression_token_type == "update" || expression_token_type == "compound") {
+        kind = expression_token_type
+        operator = expression_token_value
+        expression_lex_next()
+        right = expression_parse_assignment()
+        if (kind == "compound") {
+            identity = expression_new("identity", 0, 0, "")
+            arithmetic = expression_new("arithmetic", identity, right, substr(operator, 1, 1))
+            return expression_new("update", left, arithmetic, "")
+        }
+        return expression_new(kind, left, right, "")
+    }
+    return left
+}
+
+function expression_parse_pipe(    left, right) {
+    left = expression_parse_assignment()
     while (expression_token_type == "pipe") {
         expression_lex_next()
-        right = expression_parse_alternative()
+        right = expression_parse_assignment()
         left = expression_new("pipe", left, right, "")
     }
     return left
@@ -1461,6 +1619,244 @@ function expression_type_name(node,    resolved) {
     return "!!" node_type[resolved]
 }
 
+function expression_clone_node(source,    resolved, clone, i, collection, key, child) {
+    resolved = resolve_alias(source)
+    clone = new_node(node_kind[resolved], 0, node_value[resolved], node_type[resolved], node_tag[resolved])
+    if (node_kind[resolved] == "sequence") {
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            add_sequence(clone, expression_clone_node(sequence_child[resolved, i]), 0)
+        }
+    } else if (node_kind[resolved] == "mapping") {
+        collection = ++collection_serial
+        collect_mapping_keys(resolved, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            child = mapping_lookup(resolved, key)
+            add_mapping(clone, key, expression_clone_node(child), 0, 0)
+        }
+    }
+    return clone
+}
+
+function expression_clear_node(node,    i, key) {
+    if (node_kind[node] == "mapping") {
+        for (i = 1; i <= mapping_count[node]; i++) {
+            key = mapping_key[node, i]
+            delete mapping_seen[node SUBSEP key]
+            delete mapping_key[node, i]
+            delete mapping_child[node, i]
+            delete mapping_merge[node, i]
+        }
+        mapping_count[node] = 0
+    } else if (node_kind[node] == "sequence") {
+        for (i = 1; i <= sequence_count[node]; i++) {
+            delete sequence_child[node, i]
+        }
+        sequence_count[node] = 0
+    }
+    delete alias_target[node]
+    delete node_anchor[node]
+}
+
+function expression_attach_missing(node,    parent, key) {
+    if (!(node in expression_missing_parent) || expression_placeholder_attached[node]) {
+        return
+    }
+    parent = expression_missing_parent[node]
+    key = expression_missing_key[node]
+    if (parent in expression_missing_parent) {
+        if (node_kind[parent] == "scalar" && node_type[parent] == "null") {
+            node_kind[parent] = "mapping"
+            node_type[parent] = ""
+            node_value[parent] = ""
+        }
+        expression_attach_missing(parent)
+    }
+    if (node_kind[parent] != "mapping") {
+        fail("cannot create key " key " below " expression_type_name(parent))
+    }
+    add_mapping(parent, key, node, 0, 0)
+    expression_placeholder_attached[node] = 1
+}
+
+function expression_replace_node(target, source,    clone, saved_parent, saved_edge, saved_line, saved_document, i, key, child) {
+    if (resolve_alias(target) == resolve_alias(source) && !(target in expression_missing_parent)) {
+        return target
+    }
+    clone = expression_clone_node(source)
+    saved_parent = node_parent[target]
+    saved_edge = node_parent_edge[target]
+    saved_line = node_line[target]
+    saved_document = node_document[target]
+    expression_clear_node(target)
+    node_kind[target] = node_kind[clone]
+    node_value[target] = node_value[clone]
+    node_type[target] = node_type[clone]
+    node_tag[target] = node_tag[clone]
+    node_line[target] = saved_line
+    node_document[target] = saved_document
+    node_parent[target] = saved_parent
+    node_parent_edge[target] = saved_edge
+    if (node_kind[clone] == "sequence") {
+        for (i = 1; i <= sequence_count[clone]; i++) {
+            child = sequence_child[clone, i]
+            add_sequence(target, child, 0)
+        }
+    } else if (node_kind[clone] == "mapping") {
+        for (i = 1; i <= mapping_count[clone]; i++) {
+            key = mapping_key[clone, i]
+            child = mapping_child[clone, i]
+            add_mapping(target, key, child, 0, mapping_merge[clone, i])
+        }
+    }
+    expression_attach_missing(target)
+    return target
+}
+
+function expression_delete_node(target,    parent, i, j, key, child) {
+    if (target in expression_missing_parent && !expression_placeholder_attached[target]) {
+        return
+    }
+    parent = node_parent[target]
+    if (!parent) {
+        expression_clear_node(target)
+        node_kind[target] = "scalar"
+        node_value[target] = ""
+        node_type[target] = "null"
+        node_tag[target] = ""
+        return
+    }
+    if (node_kind[parent] == "mapping") {
+        for (i = 1; i <= mapping_count[parent]; i++) {
+            if (mapping_child[parent, i] != target) {
+                continue
+            }
+            key = mapping_key[parent, i]
+            delete mapping_seen[parent SUBSEP key]
+            for (j = i; j < mapping_count[parent]; j++) {
+                mapping_key[parent, j] = mapping_key[parent, j + 1]
+                mapping_child[parent, j] = mapping_child[parent, j + 1]
+                mapping_merge[parent, j] = mapping_merge[parent, j + 1]
+                child = mapping_child[parent, j]
+                node_parent_edge[child] = "key " mapping_key[parent, j]
+            }
+            delete mapping_key[parent, mapping_count[parent]]
+            delete mapping_child[parent, mapping_count[parent]]
+            delete mapping_merge[parent, mapping_count[parent]]
+            mapping_count[parent]--
+            return
+        }
+    } else if (node_kind[parent] == "sequence") {
+        for (i = 1; i <= sequence_count[parent]; i++) {
+            if (sequence_child[parent, i] != target) {
+                continue
+            }
+            for (j = i; j < sequence_count[parent]; j++) {
+                sequence_child[parent, j] = sequence_child[parent, j + 1]
+                child = sequence_child[parent, j]
+                node_parent_edge[child] = "index " (j - 1)
+            }
+            delete sequence_child[parent, sequence_count[parent]]
+            sequence_count[parent]--
+            return
+        }
+    }
+}
+
+function expression_collect_recursive(node, stream, serial,    resolved, seen_key, i, collection, key) {
+    resolved = resolve_alias(node)
+    seen_key = serial SUBSEP resolved
+    if (seen_key in expression_recursive_seen) {
+        return
+    }
+    expression_recursive_seen[seen_key] = 1
+    expression_stream_push(stream, resolved)
+    if (node_kind[resolved] == "sequence") {
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            expression_collect_recursive(sequence_child[resolved, i], stream, serial)
+        }
+    } else if (node_kind[resolved] == "mapping") {
+        collection = ++collection_serial
+        collect_mapping_keys(resolved, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            expression_collect_recursive(mapping_lookup(resolved, key), stream, serial)
+        }
+    }
+}
+
+function expression_arithmetic_number(value, value_type, operator,    rendered) {
+    rendered = sprintf("%.15g", value)
+    if (value_type == "float" && rendered !~ /[.eE]/) {
+        rendered = rendered ".0"
+    }
+    return expression_scalar(rendered, value_type)
+}
+
+function expression_arithmetic(left, right, operator,    left_node, right_node, left_type, right_type, result_type, value, result, i, collection, key, child) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    left_type = node_type[left_node]
+    right_type = node_type[right_node]
+
+    if (operator == "+" && left_type == "null") {
+        return expression_clone_node(right_node)
+    }
+    if (operator == "+" && right_type == "null") {
+        return expression_clone_node(left_node)
+    }
+    if ((left_type == "int" || left_type == "float") && (right_type == "int" || right_type == "float")) {
+        if (operator == "/" && expression_numeric(right_node) == 0) {
+            fail("division by zero")
+        }
+        if (operator == "%" && expression_numeric(right_node) == 0) {
+            fail("modulo by zero")
+        }
+        if (operator == "+") {
+            value = expression_numeric(left_node) + expression_numeric(right_node)
+        } else if (operator == "-") {
+            value = expression_numeric(left_node) - expression_numeric(right_node)
+        } else if (operator == "*") {
+            value = expression_numeric(left_node) * expression_numeric(right_node)
+        } else if (operator == "/") {
+            value = expression_numeric(left_node) / expression_numeric(right_node)
+        } else {
+            value = expression_numeric(left_node) % expression_numeric(right_node)
+        }
+        result_type = (operator == "/" || left_type == "float" || right_type == "float") ? "float" : "int"
+        return expression_arithmetic_number(value, result_type, operator)
+    }
+    if (operator == "+" && left_type == "string" && right_type == "string") {
+        return expression_scalar(node_value[left_node] node_value[right_node], "string")
+    }
+    if (operator == "+" && node_kind[left_node] == "sequence" && node_kind[right_node] == "sequence") {
+        result = new_node("sequence", 0, "", "", "")
+        for (i = 1; i <= sequence_count[left_node]; i++) {
+            add_sequence(result, expression_clone_node(sequence_child[left_node, i]), 0)
+        }
+        for (i = 1; i <= sequence_count[right_node]; i++) {
+            add_sequence(result, expression_clone_node(sequence_child[right_node, i]), 0)
+        }
+        return result
+    }
+    if (operator == "+" && node_kind[left_node] == "mapping" && node_kind[right_node] == "mapping") {
+        result = expression_clone_node(left_node)
+        collection = ++collection_serial
+        collect_mapping_keys(right_node, collection)
+        for (i = 1; i <= collection_count[collection]; i++) {
+            key = collection_key[collection, i]
+            child = mapping_lookup(right_node, key)
+            if (mapping_lookup(result, key)) {
+                expression_replace_node(mapping_lookup(result, key), child)
+            } else {
+                add_mapping(result, key, expression_clone_node(child), 0, 0)
+            }
+        }
+        return result
+    }
+    fail("operator " operator " does not support " expression_type_name(left_node) " and " expression_type_name(right_node))
+}
+
 function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
     output = expression_stream_new()
     kind = expression_kind[expression]
@@ -1472,6 +1868,59 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
     if (kind == "literal") {
         for (i = 1; i <= expression_stream_count[input]; i++) {
             expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "array" || kind == "object") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            if (kind == "array") {
+                result_node = new_node("sequence", 0, "", "", "")
+                for (j = 1; j <= expression_child_count[expression]; j++) {
+                    middle = expression_evaluate(expression_child[expression, j], single)
+                    for (collection = 1; collection <= expression_stream_count[middle]; collection++) {
+                        add_sequence(result_node, expression_clone_node(expression_stream_node[middle, collection]), 0)
+                    }
+                }
+            } else {
+                result_node = new_node("mapping", 0, "", "", "")
+                for (j = 1; j <= expression_child_count[expression]; j++) {
+                    middle = expression_evaluate(expression_child[expression, j], single)
+                    child = expression_stream_count[middle] ? expression_stream_node[middle, 1] : expression_null()
+                    add_mapping(result_node, expression_object_key[expression, j], expression_clone_node(child), 0, 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "recursive") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_collect_recursive(expression_stream_node[input, i], output, ++expression_recursive_serial)
+        }
+        return output
+    }
+    if (kind == "negate") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = resolve_alias(expression_stream_node[middle, i])
+            if (node_type[node] != "int" && node_type[node] != "float") {
+                fail("unary - requires a number")
+            }
+            expression_stream_push(output, expression_arithmetic_number(-expression_numeric(node), node_type[node], "-"))
+        }
+        return output
+    }
+    if (kind == "arithmetic") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                for (collection = 1; collection <= expression_stream_count[right_stream]; collection++) {
+                    expression_stream_push(output, expression_arithmetic(expression_stream_node[left_stream, j], expression_stream_node[right_stream, collection], expression_value[expression]))
+                }
+            }
         }
         return output
     }
@@ -1490,14 +1939,25 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                 } else {
                     child = 0
                 }
-                expression_stream_push(output, child ? child : expression_null())
+                if (child) {
+                    expression_stream_push(output, child)
+                } else if (!expression_optional[expression]) {
+                    child = expression_null()
+                    expression_missing_parent[child] = resolved
+                    expression_missing_key[child] = expression_value[expression]
+                    expression_stream_push(output, child)
+                }
             } else if (kind == "index") {
                 if (node_kind[resolved] == "sequence" && expression_value[expression] < sequence_count[resolved]) {
                     child = sequence_child[resolved, expression_value[expression] + 1]
                 } else {
                     child = 0
                 }
-                expression_stream_push(output, child ? child : expression_null())
+                if (child) {
+                    expression_stream_push(output, child)
+                } else if (!expression_optional[expression]) {
+                    expression_stream_push(output, expression_null())
+                }
             } else if (node_kind[resolved] == "sequence") {
                 for (j = 1; j <= sequence_count[resolved]; j++) {
                     expression_stream_push(output, sequence_child[resolved, j])
@@ -1510,12 +1970,46 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                     expression_stream_push(output, mapping_lookup(resolved, key))
                 }
             } else {
+                if (expression_optional[expression]) {
+                    continue
+                }
                 if (node_kind[resolved] == "scalar") {
                     fail("cannot iterate over " node_type[resolved])
                 }
                 fail("cannot iterate over " node_kind[resolved])
             }
         }
+        return output
+    }
+    if (kind == "assign" || kind == "update") {
+        left_stream = expression_evaluate(expression_left[expression], input)
+        if (kind == "assign") {
+            right_stream = expression_evaluate(expression_right[expression], input)
+            if (!expression_stream_count[right_stream]) {
+                expression_stream_push(right_stream, expression_null())
+            }
+            for (i = 1; i <= expression_stream_count[left_stream]; i++) {
+                j = expression_stream_count[right_stream] == expression_stream_count[left_stream] ? i : 1
+                expression_replace_node(expression_stream_node[left_stream, i], expression_stream_node[right_stream, j])
+            }
+        } else {
+            for (i = 1; i <= expression_stream_count[left_stream]; i++) {
+                node = expression_stream_node[left_stream, i]
+                single = expression_stream_single(node)
+                right_stream = expression_evaluate(expression_right[expression], single)
+                child = expression_stream_count[right_stream] ? expression_stream_node[right_stream, 1] : expression_null()
+                expression_replace_node(node, child)
+            }
+        }
+        expression_stream_append(output, input)
+        return output
+    }
+    if (kind == "del") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = expression_stream_count[middle]; i >= 1; i--) {
+            expression_delete_node(expression_stream_node[middle, i])
+        }
+        expression_stream_append(output, input)
         return output
     }
     if (kind == "select") {
@@ -1758,6 +2252,129 @@ function emit_json(node,    resolved, stack_key, i, collection, key, child, lowe
     delete json_stack[stack_key]
 }
 
+function yaml_spaces(indent,    result, i) {
+    result = ""
+    for (i = 0; i < indent; i++) {
+        result = result " "
+    }
+    return result
+}
+
+function yaml_properties(node,    result, tag) {
+    result = ""
+    tag = node_tag[node]
+    if (tag != "") {
+        if (tag ~ /^tag:yaml.org,2002:/) {
+            tag = "!!" substr(tag, length("tag:yaml.org,2002:") + 1)
+        } else {
+            tag = "!<" tag ">"
+        }
+        result = tag
+    }
+    if (node_anchor[node] != "") {
+        if (result != "") {
+            result = result " "
+        }
+        result = result "&" node_anchor[node]
+    }
+    return result
+}
+
+function yaml_scalar_text(node,    value, properties, lowered) {
+    if (node_kind[node] == "alias") {
+        return "*" node_value[node]
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        properties = properties " "
+    }
+    value = node_value[node]
+    if (node_type[node] == "null") {
+        return properties "null"
+    }
+    if (node_type[node] == "bool") {
+        lowered = tolower(value)
+        if (lowered == "true" || lowered == "false") {
+            return properties lowered
+        }
+    }
+    if (node_type[node] == "int" || node_type[node] == "float" || node_type[node] == "timestamp") {
+        return properties value
+    }
+    return properties json_quote(value)
+}
+
+function yaml_inline_node(node,    properties) {
+    if (node_kind[node] == "scalar" || node_kind[node] == "alias") {
+        return yaml_scalar_text(node)
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        properties = properties " "
+    }
+    if (node_kind[node] == "mapping" && mapping_count[node] == 0) {
+        return properties "{}"
+    }
+    if (node_kind[node] == "sequence" && sequence_count[node] == 0) {
+        return properties "[]"
+    }
+    return ""
+}
+
+function emit_yaml_collection(node, indent,    i, child, inline, properties, key) {
+    if (node_kind[node] == "mapping") {
+        for (i = 1; i <= mapping_count[node]; i++) {
+            key = mapping_key[node, i]
+            if (mapping_merge[node, i]) {
+                printf "%s<<:", yaml_spaces(indent)
+            } else {
+                printf "%s%s:", yaml_spaces(indent), json_quote(key)
+            }
+            child = mapping_child[node, i]
+            inline = yaml_inline_node(child)
+            if (inline != "") {
+                printf " %s\n", inline
+            } else {
+                properties = yaml_properties(child)
+                if (properties != "") {
+                    printf " %s", properties
+                }
+                printf "\n"
+                emit_yaml_collection(child, indent + 2)
+            }
+        }
+        return
+    }
+    for (i = 1; i <= sequence_count[node]; i++) {
+        child = sequence_child[node, i]
+        printf "%s-", yaml_spaces(indent)
+        inline = yaml_inline_node(child)
+        if (inline != "") {
+            printf " %s\n", inline
+        } else {
+            properties = yaml_properties(child)
+            if (properties != "") {
+                printf " %s", properties
+            }
+            printf "\n"
+            emit_yaml_collection(child, indent + 2)
+        }
+    }
+}
+
+function emit_yaml(node,    inline, properties) {
+    inline = yaml_inline_node(node)
+    if (inline != "") {
+        print inline
+        return
+    }
+    properties = yaml_properties(node)
+    if (properties != "") {
+        print properties
+    }
+    emit_yaml_collection(node, 0)
+}
+
 function output_ast(document,    node, i) {
     for (node = 1; node <= node_count; node++) {
         if (node_document[node] != document) {
@@ -1848,6 +2465,8 @@ function output_expression_node(target, output_mode,    resolved) {
     } else if (output_mode == "json") {
         emit_json(target)
         printf "\n"
+    } else if (output_mode == "yaml") {
+        emit_yaml(target)
     } else if (node_kind[resolved] == "scalar") {
         print node_value[resolved]
     } else {
@@ -1874,6 +2493,9 @@ function output_result(document, query, output_mode,    root, expression, input,
     input = expression_stream_single(root)
     results = expression_evaluate(expression, input)
     for (i = 1; i <= expression_stream_count[results]; i++) {
+        if (output_mode == "yaml" && i > 1) {
+            print "---"
+        }
         output_expression_node(expression_stream_node[results, i], output_mode)
     }
 }
@@ -1915,7 +2537,19 @@ END {
         finalize_nodes()
         validate_aliases()
         validate_merges()
-        output_result(selected_document + 0, query, output_mode)
+        if (inplace_mode) {
+            document_total = 0
+            for (document_number in document_root) {
+                document_total++
+            }
+            if (document_total > 1) {
+                print "Error: --inplace does not yet support multi-document streams" > "/dev/stderr"
+                exit_status = 1
+            }
+        }
+        if (!exit_status) {
+            output_result(selected_document + 0, query, output_mode)
+        }
     }
     exit exit_status
 }
@@ -1937,15 +2571,19 @@ Usage:
 Examples:
   ysh ".server.host" config.yml
   ysh ".services[] | select(.enabled) | .name" config.yml
+  ysh -o yaml '.release.channel = "stable"' config.yml
+  ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
+  ysh -n -o yaml '{name: "api", enabled: true}'
   ysh ".services | length" config.yml
   ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
   printf "%s\\n" "answer: 42" | ysh ".answer"
 
 Output:
-  -o, --output FORMAT      value, raw, or json
+  -o, --output FORMAT      value, raw, json, or yaml
   -r, --raw-output        print scalar values without JSON quoting
       --json              emit JSON
+  -y, --yaml-output       emit YAML
       --type              print the selected node type
       --tag               print the selected node tag
       --line              print the selected node source line
@@ -1954,14 +2592,17 @@ Output:
 
 Documents:
   -d, --document INDEX    select a zero-based YAML document
+  -n, --null-input        build output without reading input
+  -i, --inplace           update a YAML file in place
 
 Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY supports yq-style paths, [], pipes, select, comparisons, boolean
-operators, // defaults, length, keys, has, kind, and type. Collections
-are emitted as JSON by default; streams emit one result per line.
+QUERY supports yq-style paths, [], .., ?, pipes, select, comparisons,
+boolean operators, // defaults, construction, =, |=, del, length, keys,
+has, kind, and type. Collections are emitted as JSON by default; streams
+emit one result per line. In-place updates are serialized as YAML.
 EOF
 }
 
@@ -1969,6 +2610,7 @@ ysh_set_output_mode() {
     case "$1" in
     value|raw) YSH_OUTPUT_MODE="value" ;;
     json) YSH_OUTPUT_MODE="json" ;;
+    yaml|yml) YSH_OUTPUT_MODE="yaml" ;;
     *)
         ysh_error "unsupported output format: $1"
         return 2
@@ -1977,20 +2619,50 @@ ysh_set_output_mode() {
 }
 
 ysh_run_awk() {
-    if [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+    if [ "$YSH_NULL_INPUT" -eq 1 ]; then
         awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
+            "$YAML_AWK_PARSER" \
+            /dev/null
+    elif [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+        awk \
+            -v query="$YSH_QUERY" \
+            -v output_mode="$YSH_OUTPUT_MODE" \
+            -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER"
     else
         awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
+            -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER" \
             "$YSH_INPUT_FILE"
     fi
+}
+
+ysh_run_inplace() {
+    YSH_TEMP_FILE=${YSH_INPUT_FILE}.ysh.$$
+    if ! (umask 077 && set -C && : > "$YSH_TEMP_FILE") 2>/dev/null; then
+        ysh_error "could not create temporary file beside: $YSH_INPUT_FILE"
+        return 1
+    fi
+    trap 'rm -f "$YSH_TEMP_FILE"' 0
+    trap 'exit 1' 1 2 3 15
+    YSH_OUTPUT_MODE=yaml
+    if ! ysh_run_awk > "$YSH_TEMP_FILE"; then
+        return 1
+    fi
+    if ! cp "$YSH_TEMP_FILE" "$YSH_INPUT_FILE"; then
+        ysh_error "could not replace input file: $YSH_INPUT_FILE"
+        return 1
+    fi
+    rm -f "$YSH_TEMP_FILE"
+    trap - 0 1 2 3 15
 }
 
 ysh_main() {
@@ -1998,6 +2670,8 @@ ysh_main() {
     YSH_DOCUMENT=0
     YSH_QUERY=.
     YSH_INPUT_FILE=
+    YSH_NULL_INPUT=0
+    YSH_INPLACE=0
     YSH_POSITIONAL_COUNT=0
     YSH_POSITIONAL_ONE=
     YSH_POSITIONAL_TWO=
@@ -2024,6 +2698,10 @@ ysh_main() {
             YSH_OUTPUT_MODE="json"
             shift
             ;;
+        -y|--yaml-output)
+            YSH_OUTPUT_MODE="yaml"
+            shift
+            ;;
         --type)
             YSH_OUTPUT_MODE="type"
             shift
@@ -2042,6 +2720,14 @@ ysh_main() {
             ;;
         --events)
             YSH_OUTPUT_MODE="events"
+            shift
+            ;;
+        -n|--null-input)
+            YSH_NULL_INPUT=1
+            shift
+            ;;
+        -i|--inplace|--in-place)
+            YSH_INPLACE=1
             shift
             ;;
         -d|--document)
@@ -2130,6 +2816,19 @@ ysh_main() {
     if [ -n "$YSH_INPUT_FILE" ] && [ "$YSH_INPUT_FILE" != "-" ] && [ ! -f "$YSH_INPUT_FILE" ]; then
         ysh_error "input file does not exist: $YSH_INPUT_FILE"
         return 1
+    fi
+
+    if [ "$YSH_INPLACE" -eq 1 ]; then
+        if [ "$YSH_NULL_INPUT" -eq 1 ]; then
+            ysh_error "--inplace cannot be combined with --null-input"
+            return 2
+        fi
+        if [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
+            ysh_error "--inplace requires an input file"
+            return 2
+        fi
+        ysh_run_inplace
+        return $?
     fi
 
     ysh_run_awk


### PR DESCRIPTION
## What changed

YAML.sh now has a writable node-stream evaluator and semantic YAML emitter while keeping the released artifact to one POSIX `/bin/sh` + AWK file.

- add recursive descent (`..`) and optional traversal (`?`)
- add array/object construction and null-input mode (`-n`)
- add arithmetic plus string, sequence, and shallow mapping `+`
- add `=`, `|=`, compound updates, missing-path creation, and `del(...)`
- add YAML output (`-y`, `-o=yaml`) and permission-preserving in-place updates (`-i`)
- reject multi-document in-place updates before touching the source file
- rebuild the README, website copy, docs, support contract, internals, migration guide, and changelog for v1.2

## Verification

- `make all`
- 57 behavioral tests
- ShellCheck on the generated artifact, tests, and installer
- YAML emitter round-trips the advanced anchor/alias/merge/tag fixture
- in-place updates preserve permissions and leave multi-document inputs unchanged on rejection
- 18 representative v1.2 expressions match yq v4.53.3 byte-for-byte in JSON mode
- local Chrome visual QA of the landing page and docs; no console errors

## Honest boundaries

The YAML emitter preserves semantic structure, not comments or presentation style. Variables, interpolation, regex/reducers, dynamic keys, slices, deep merge, style/comment operators, file operators, and non-YAML codecs remain outside v1.2. Updates through aliases or inherited merge values retain shared graph identity.