### PR TITLE
YAML.sh v2: the tiny YAML programming language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to YAML.sh are documented here.
 
+## [2.0.0] - 2026-08-02
+
+Version 2 completes the journey from a path reader to a compact YAML programming tool. It adds collection programming, lexical variables, reducers, broader YAML syntax, multi-document updates, and a hybrid presentation-preserving in-place editor while remaining one portable `/bin/sh` + AWK file.
+
+### Added
+
+- Comma streams plus `map(...)` and `map_values(...)` collection transforms.
+- `to_entries`, `from_entries`, and `with_entries(...)` mapping workflows.
+- `sort`, stable `unique`, `reverse`, and recursive `flatten` sequence helpers.
+- `upcase`, `downcase`, `contains`, `startswith`, `endswith`, `split`, and `join` string helpers.
+- Lexical variables with `as $name`, variable references, and dynamic mapping/sequence indexes.
+- A yq-shaped `reduce SOURCE as $item (INITIAL; UPDATE)` evaluator.
+- Recursive mapping merge with `*`, while retaining numeric multiplication.
+- Unicode `\u` and `\U` escapes, multiline flow collections, and explicit block-scalar indentation indicators.
+- Multi-document in-place transformations evaluated independently against every document.
+- Hybrid presentation preservation: safe scalar replacements retain comments, blank lines, layout, and plain/single/double quote style.
+- Seven new behavioral groups covering the v2 evaluator, parser, multi-document writer, and presentation layer, bringing the suite to 64 tests.
+
+### Changed
+
+- Pipe parsing is right-associative so variable binding receives the correct current input.
+- Structural in-place changes use the deterministic semantic YAML emitter; scalar-only changes patch the original source.
+- `unique` preserves first-occurrence order, matching yq v4.53.3.
+
+### Known boundaries
+
+- Presentation preservation currently applies to scalar replacements. Construction, deletion, deep merge, flow-node edits, and other structural changes intentionally fall back to semantic YAML.
+- Collection-valued mapping keys, recursive aliases, full schema-dependent resolution, every block-folding edge case, and complete YAML specification validation remain outside the parser contract.
+- Regexes, string interpolation, slices, date/time operators, file-loading operators, comment/style mutation operators, and non-YAML codecs remain outside the expression language.
+- In-place mode uses POSIX `cp` and `rm`; all other operation continues to require only `/bin/sh` and AWK.
+
 ## [1.2.0] - 2026-08-01
 
 Version 1.2 turns the expression stream into a writable graph and adds a semantic YAML emitter. YAML.sh can now construct, transform, and safely rewrite documents while keeping its one-file `/bin/sh` + AWK runtime.
@@ -141,6 +172,7 @@ Version 1 is a ground-up, intentionally breaking rebuild around a real YAML node
 
 - Report missing files and make the help flag exit successfully.
 
+[2.0.0]: https://github.com/azohra/yaml.sh/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/azohra/yaml.sh/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/azohra/yaml.sh/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/azohra/yaml.sh/compare/v0.4.0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="_static/_www/og.png" alt="YAML.sh v1 — yq energy, zero baggage" width="900">
+  <img src="_static/_www/og.png" alt="YAML.sh v2 — yq energy, zero baggage" width="900">
 </p>
 
 <p align="center">
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v1.2.0" src="https://img.shields.io/badge/release-v1.2.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
+  <a href="https://github.com/azohra/yaml.sh/releases/latest"><img alt="YAML.sh v2.0.0" src="https://img.shields.io/badge/release-v2.0.0-d8ff45?style=for-the-badge&labelColor=101410"></a>
   <a href="https://github.com/azohra/yaml.sh/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/azohra/yaml.sh/ci.yml?style=for-the-badge&label=tests&labelColor=101410"></a>
   <img alt="POSIX shell plus AWK" src="https://img.shields.io/badge/runtime-sh_+_awk-f5f1e8?style=for-the-badge&labelColor=101410">
 </p>
@@ -54,7 +54,7 @@ Mappings stay mappings. Empty sequences survive. Aliases retain identity. Keys c
 ## Install one file
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v2.0.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -112,7 +112,7 @@ ysh '.missing // "fallback"' config.yml
 
 ## Make it change things
 
-Version 1.2 gives those node references teeth. Assign values, build missing paths, update relative to the current value, or delete a node:
+Version 2 gives those node references a small programming language. Assign values, build missing paths, update relative to the current value, or delete a node:
 
 ```sh
 ysh -o=yaml '.release.channel = "stable"' config.yml
@@ -126,7 +126,7 @@ Ready to commit to the bit?
 ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
 ```
 
-`-i` requires a real single-document file, writes valid YAML only after the full parse and transformation succeeds, and preserves the existing file permissions. It intentionally normalizes presentation: comments, blank lines, scalar style, and key quoting are not retained. Multi-document streams remain queryable but are rejected by `-i` in v1.2 so unselected documents can never be silently dropped.
+`-i` requires a real file, writes only after every document parses and transforms successfully, and preserves its permissions. Version 2 patches scalar-only changes into the original source, retaining comments, blank lines, key layout, and plain/single/double quote style. Structural changes automatically fall back to deterministic semantic YAML. Multi-document files are transformed document by document.
 
 Construct a fresh document without reading input:
 
@@ -140,6 +140,17 @@ And yes, AWK is now doing arithmetic too:
 ysh -n --json '2 + 3 * 4'
 # 14
 ```
+
+Version 2 also crosses the line from query syntax into collection programming:
+
+```sh
+ysh '.services | map(.name) | unique' config.yml
+ysh '.metadata | with_entries(.value |= upcase)' config.yml
+ysh '.key as $key | .data[$key]' config.yml
+ysh 'reduce .services[].port as $port (0; . + $port)' config.yml
+```
+
+There are comma streams, variables, dynamic indexes, `map`/`map_values`, entries, sorting, uniqueness, flattening, string operations, reducers, and recursive mapping merge. It is still deliberately smaller than yq; the exact boundary is part of the documentation rather than a surprise in production.
 
 Pipe YAML in naturally:
 
@@ -166,7 +177,7 @@ ysh '.metadata["build[number]"]' config.yml
 | Partial merge handling | Alias lists, flow mappings, and block merge sequences |
 | Parser internals hidden | `--ast` and `--events` on tap |
 
-Version 1.1 added streaming reads. Version 1.2 adds recursive and optional traversal, construction, arithmetic, assignments, deletion, YAML output, null input, and in-place editing without changing the one-file runtime. The original v1 CLI break remains intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
+Version 1 established the graph and writable evaluator. Version 2 adds collection programming, variables, reducers, deeper YAML syntax, multi-document mutation, and hybrid presentation-preserving edits without changing the one-file runtime. The original v1 CLI break remains intentional. See the [migration guide](_static/_www/docs/migration.md) if an old script still speaks `-f ... -Q ...`.
 
 ## Open the hood
 
@@ -223,7 +234,7 @@ That contract is the promise: supported syntax gets a test; neighboring unsuppor
 make all
 ```
 
-That rebuilds the standalone `ysh`, runs ShellCheck, and executes 57 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
+That rebuilds the standalone `ysh`, runs ShellCheck, and executes 64 behavioral tests. Hosted CI repeats the suite with macOS AWK, Ubuntu AWK, BusyBox AWK, and `/bin/sh`.
 
 The constraint is the fun part. Come make AWK do something unreasonable.
 

--- a/_static/_www/docs/README.md
+++ b/_static/_www/docs/README.md
@@ -2,7 +2,7 @@
 
 YAML.sh is a yq-like query tool delivered as one portable shell script. It runs with the system `/bin/sh` and AWK, making it useful in bootstrap scripts, minimal containers, CI jobs, old machines, and every awkward environment where installing a language runtime feels absurd.
 
-> Version 1 is a ground-up architecture change: YAML is parsed into a node graph, references are resolved, and only then does the expression engine stream results.
+> Version 2 completes the architecture: YAML becomes a writable node graph, the expression engine programs streams of references, and in-place scalar edits can patch the original presentation.
 
 ```sh
 ysh '.server.host' config.yml
@@ -35,7 +35,7 @@ YAML.sh aims for the useful middle: familiar yq-style paths, streams, filters, c
 | Tag syntax mostly discarded | Expanded tags attached to nodes |
 | Inline merge subset | Alias lists, flow mappings, and block merge sequences |
 
-Version 1.1 added iteration, pipes, selection, comparisons, booleans, defaults, and collection helpers above that graph. Version 1.2 makes references writable and adds recursive and optional traversal, arithmetic, construction, assignment, deletion, YAML output, and in-place updates.
+Version 1 made the graph writable. Version 2 adds maps, entries, variables, dynamic indexes, reducers, strings, sorting, deep merge, broader YAML syntax, multi-document mutation, and presentation-preserving scalar edits.
 
 ## Pick a path
 

--- a/_static/_www/docs/documents.md
+++ b/_static/_www/docs/documents.md
@@ -23,3 +23,11 @@ ysh -d 1 '.environment' stream.yml
 ```
 
 Anchors and tag handles are scoped to their document. Empty explicit documents are represented as null rather than disappearing from the stream.
+
+In-place mode applies the same expression independently to every document:
+
+```sh
+ysh -i '.release.channel = "stable"' stream.yml
+```
+
+The update is committed only after the entire stream parses and every document transforms successfully.

--- a/_static/_www/docs/getting-started.md
+++ b/_static/_www/docs/getting-started.md
@@ -5,7 +5,7 @@ YAML.sh ships as one executable text file. The released file contains both the p
 ## Install the pinned release
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o ysh
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v2.0.0/ysh -o ysh
 chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
@@ -89,7 +89,7 @@ Once the result looks right, update the file in place:
 ysh -i '.release.channel = "stable"' config.yml
 ```
 
-In-place output preserves the file permissions but normalizes YAML presentation. Comments and original formatting are not retained, so review the diff like the tiny chaos engineer you are.
+In-place output preserves file permissions. Scalar-only changes also preserve comments, blank lines, layout, and plain/single/double quote style. Structural changes use normalized semantic YAML, so review the diff like the tiny chaos engineer you are.
 
 ## Standard input
 

--- a/_static/_www/docs/index.html
+++ b/_static/_www/docs/index.html
@@ -3,22 +3,22 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="YAML.sh v1 documentation — a yq-like YAML query tool in one portable shell script.">
+  <meta name="description" content="YAML.sh v2 documentation — a yq-like YAML programming tool in one portable shell script.">
   <meta name="theme-color" content="#101410">
-  <meta property="og:title" content="YAML.sh v1 documentation">
+  <meta property="og:title" content="YAML.sh v2 documentation">
   <meta property="og:description" content="Queries, output formats, YAML support, migration, and parser internals.">
   <meta property="og:image" content="https://yaml.azohra.com/og.png">
   <link rel="canonical" href="https://yaml.azohra.com/docs/">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-  <link rel="stylesheet" href="theme.css?v=1.2.0">
-  <title>YAML.sh v1 docs</title>
+  <link rel="stylesheet" href="theme.css?v=2.0.0">
+  <title>YAML.sh v2 docs</title>
 </head>
 <body>
   <a class="skip-link" href="#app">Skip to documentation</a>
   <header class="docs-header">
     <a class="docs-brand" href="https://yaml.azohra.com" aria-label="YAML.sh home">
-      <span>Y</span><b>YAML.sh</b><i>v1 docs</i>
+      <span>Y</span><b>YAML.sh</b><i>v2 docs</i>
     </a>
     <nav aria-label="Documentation links">
       <a href="/">Website</a>
@@ -37,7 +37,7 @@
       auto2top: true,
       relativePath: true,
       search: {
-        placeholder: 'Search v1 docs',
+        placeholder: 'Search v2 docs',
         noData: 'No matching nodes.',
         depth: 4
       },

--- a/_static/_www/docs/internals.md
+++ b/_static/_www/docs/internals.md
@@ -1,6 +1,6 @@
 # Parser internals
 
-Version 1 is still one shell script, but its model is no longer line-oriented query output.
+Version 2 is still one shell script, with a semantic graph and a source-presentation layer working together.
 
 ```text
 /bin/sh CLI
@@ -15,7 +15,7 @@ expression parser
     ↓
 node-stream evaluator
     ↓
-value / JSON / YAML / type / tag / line / AST / events
+presentation patcher or value / JSON / YAML / metadata / AST / events
 ```
 
 ## The shell layer
@@ -53,11 +53,11 @@ Merge entries remain marked edges in the graph. Lookup checks explicit entries f
 
 ## Expression streams
 
-The expression parser builds a small operator tree with explicit precedence for pipes, assignment, alternatives, booleans, comparisons, arithmetic, and traversal. Evaluation passes numbered streams of node references between operators. `[]` and `..` can expand one node into many references; `select` tests each reference while returning the original node when its predicate succeeds.
+The expression parser builds an operator tree with explicit precedence for streams, lexical binding, pipes, assignment, alternatives, booleans, comparisons, arithmetic, and traversal. Evaluation passes numbered streams of node references between operators. Variables hold node identity; dynamic indexes evaluate computed keys; reducers repeatedly bind an item while feeding an accumulator through the update expression.
 
 Because streams contain node IDs rather than copied values, type, tag, source line, alias identity, parentage, and merge behavior survive a pipeline. Assignments replace the selected graph nodes; missing mapping paths use attachable placeholders. Computed booleans, strings, numbers, constructed collections, and key lists are represented as temporary graph nodes and use the same output path as parsed YAML.
 
-The YAML emitter walks that graph directly. It preserves semantic structure and graph properties where possible, while deliberately normalizing presentation into a stable quoted block style.
+The semantic YAML emitter walks that graph directly and normalizes presentation into a stable quoted block style. Separately, the v2 presentation tracker records safe scalar replacements by source line. In-place mode patches those tokens into the original lines when possible; any structural mutation flips the operation to the semantic emitter for the complete document stream.
 
 ## Diagnostics
 

--- a/_static/_www/docs/migration.md
+++ b/_static/_www/docs/migration.md
@@ -67,7 +67,7 @@ The following v0.x flags are not accepted in v1:
 - `-T`, because the transpiled representation is gone.
 - `-q` and `-Q`, because the positional query replaces them.
 - `-s`, `-l`, `-L`, `-c`, and `-I`, because node selection uses one query grammar.
-- The v0.x meaning of `-i`. Version 1.2 reuses `-i` for yq-style in-place file updates.
+- The v0.x meaning of `-i`. Modern YAML.sh reuses `-i` for yq-style in-place file updates; v2 preserves presentation for scalar-only changes.
 - `--next`, because `--document N` addresses a document directly.
 
 If a script depends on v0.x behavior, pin `v0.4.0` while migrating.

--- a/_static/_www/docs/output.md
+++ b/_static/_www/docs/output.md
@@ -46,9 +46,9 @@ ysh -o=yaml '.release.channel = "stable"' config.yml
 
 Multiple results are separated with `---`, producing a valid YAML stream. Anchors, aliases, tags, and merge edges are emitted when they still exist in the selected graph.
 
-The emitter is semantic, not presentation-preserving. It deliberately uses a stable block layout and quotes string values and ordinary mapping keys. Comments, blank lines, original quote choices, flow-vs-block style, directive spelling, and exact scalar formatting are not retained.
+The emitter is semantic. It deliberately uses a stable block layout and quotes string values and ordinary mapping keys. Comments, blank lines, original quote choices, flow-vs-block style, directive spelling, and exact scalar formatting are not retained when this emitter is selected directly.
 
-`-i` always uses this YAML emitter. It parses and transforms into a sibling temporary file first, copies the successful result over the requested file, and preserves the destination's existing permission bits. Version 1.2 rejects multi-document in-place updates before replacement so an unselected document cannot be lost.
+Version 2 adds a hybrid presentation layer to `-i`. When every change is a safely patchable scalar replacement, YAML.sh rewrites only those scalar tokens in the original source, preserving comments, blank lines, layout, and plain/single/double quote style. Structural changes automatically fall back to the semantic emitter. Every document is transformed, and replacement still occurs through a sibling temporary file while preserving the destination's permission bits.
 
 ## Type
 

--- a/_static/_www/docs/queries.md
+++ b/_static/_www/docs/queries.md
@@ -1,6 +1,6 @@
 # Queries
 
-Version 1.2 evaluates a focused yq-style expression language over streams of writable node references. Paths select exact nodes; iteration and pipes let one input become many results; assignments change the graph those references belong to.
+Version 2 evaluates a focused yq-style programming language over streams of writable node references. Paths select exact nodes; pipes and comma expressions shape streams; assignments change the graph those references belong to.
 
 ## Paths
 
@@ -118,6 +118,49 @@ Filters can begin an expression when they operate on the root:
 ysh 'length' config.yml
 ```
 
+## Collection programming
+
+Comma expressions emit both sides. `map` always produces a sequence; `map_values` preserves a mapping or sequence while transforming its values.
+
+```sh
+ysh '.metadata.owner, .metadata.region' config.yml
+ysh --json '.services | map(.name)' config.yml
+ysh --json '.metadata | map_values(upcase)' config.yml
+```
+
+Mappings and sequences can move through the familiar entry representation:
+
+```sh
+ysh --json '.metadata | to_entries' config.yml
+ysh --json '.metadata | with_entries(.value |= upcase)' config.yml
+ysh --json '.metadata | to_entries | from_entries' config.yml
+```
+
+Sequence helpers include `sort`, stable first-occurrence `unique`, `reverse`, and recursive `flatten`. String helpers include `upcase`, `downcase`, `contains(...)`, `startswith(...)`, `endswith(...)`, `split(...)`, and `join(...)`.
+
+```sh
+ysh -n --json '[3, 1, 2, 1] | unique'
+ysh -n --json '[[1, 2], [3, [4]]] | flatten'
+ysh -n --json '["yaml", "sh"] | join(".")'
+```
+
+## Variables, dynamic indexes, and reduce
+
+Bind a result with `as $name`. The expression after the pipe keeps the original current input and can refer to that value repeatedly:
+
+```sh
+ysh '.metadata as $meta | {owner: $meta.owner, region: $meta.region}' config.yml
+ysh '.key as $key | .data[$key]' config.yml
+```
+
+Dynamic brackets accept a computed string key or integer index. `reduce` folds a stream into one value:
+
+```sh
+ysh 'reduce .services[].port as $port (0; . + $port)' config.yml
+```
+
+The `*` operator recursively merges two mappings; at non-mapping leaves, the right side wins. It remains numeric multiplication for two numbers.
+
 ## Construct values
 
 Array and object literals can collect results from the current input. Unquoted identifier keys are accepted as a friendly extension; quoted keys work too.
@@ -147,7 +190,7 @@ The compound forms `+=`, `-=`, `*=`, `/=`, and `%=` are relative arithmetic upda
 ysh -o=yaml '(.services[] | select(.enabled) | .tier) = "active"' config.yml
 ```
 
-Use `-i` to replace a real single-document input file after a successful transform. In-place mode always emits YAML, cannot be combined with standard input or `-n`, and rejects multi-document streams in v1.2.
+Use `-i` to replace a real input file after every document transforms successfully. It cannot be combined with standard input or `-n`. Scalar-only edits preserve the original presentation; structural edits use stable semantic YAML. Multi-document files are evaluated document by document.
 
 ## Merged and aliased nodes
 
@@ -157,6 +200,6 @@ Aliases are genuine shared graph references. Updating through an alias or an inh
 
 ## Current expression boundary
 
-This is a useful yq-shaped language, not the complete yq language. Version 1.2 does not implement variables, string interpolation, regular expressions, dynamic object keys, slices, reduce/ireduce, sort/group/unique operators, file operators, date operators, XML/CSV/TOML codecs, style/comment operators, or yq's full deep-merge and cross-document semantics.
+This is a useful yq-shaped language, not the complete yq language. Version 2 does not implement string interpolation, regular expressions, slices, grouping, ireduce, date operators, file-loading operators, XML/CSV/TOML codecs, comment/style mutation operators, or yq's complete cross-document and flag surface.
 
 Supported transformations are tested against their expected graph behavior. For automation that needs arbitrary yq programs, use yq; YAML.sh is for the delightfully constrained machine where installing yq is the problem you are trying to solve.

--- a/_static/_www/docs/supported_yml.md
+++ b/_static/_www/docs/supported_yml.md
@@ -7,6 +7,7 @@ YAML.sh is a query-oriented YAML implementation with a tested support contract. 
 - Nested block mappings using space indentation.
 - Block sequences in indented and indentationless styles.
 - Single-line flow sequences and mappings.
+- Multiline flow sequences and mappings.
 - Expanded and flow mappings inside sequences.
 - Empty flow mappings (`{}`) and sequences (`[]`).
 - Duplicate mapping-key rejection.
@@ -16,8 +17,10 @@ YAML.sh is a query-oriented YAML implementation with a tested support contract. 
 
 - Plain, single-quoted, and double-quoted scalars.
 - Common double-quoted escapes for newlines, tabs, returns, quotes, slashes, and backslashes.
+- Four- and eight-digit Unicode escapes using `\u` and `\U`.
 - Literal (`|`) and folded (`>`) block scalars.
 - Strip (`-`), clip, and keep (`+`) chomping behavior for common block scalars.
+- Explicit block-scalar indentation indicators from 1 through 9.
 - Lexical recognition of strings, nulls, booleans, binary/octal/decimal/hexadecimal integers, floats, and timestamps.
 
 Values remain text in default output. Type recognition is used by `--type` and JSON output.
@@ -64,17 +67,17 @@ YAML version directives are validated but do not switch between complete YAML 1.
 - Anchor names are limited to letters, digits, `_`, and `-`.
 - Collection-valued mapping keys are rejected. Explicit scalar keys are supported.
 - Anchors and tags on mapping keys are not implemented.
-- Flow collections must fit on one line.
 - The complete YAML Unicode escape repertoire and every block-folding edge case are not implemented.
 - Full YAML 1.1/1.2 schema resolution and application-specific construction are not implemented.
-- YAML emission preserves data, node kinds, tags, anchors, aliases, and merge edges where representable, but not comments or original presentation style.
+- Semantic YAML emission preserves data, node kinds, tags, anchors, aliases, and merge edges where representable, but not comments or original presentation style.
+- In-place scalar replacements preserve comments and surrounding presentation. Structural changes deliberately fall back to semantic YAML.
 - Updating through an alias or inherited merge value follows shared node identity and can change the anchor or merge source.
-- The expression language does not implement variables, interpolation, regular expressions, reducers, dynamic keys, slices, deep-merge operators, comment/style operators, file operators, or yq's non-YAML codecs.
+- The expression language does not implement interpolation, regular expressions, slices, grouping, ireduce, comment/style mutation operators, file-loading operators, or yq's non-YAML codecs.
 
 YAML.sh does not evaluate YAML as shell code, but it is not a complete specification validator. Use a maintained full YAML library when exact conformance for arbitrary or hostile input is a hard requirement.
 
 ## Conformance fixture
 
-The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. The expression fixture covers node streams, iteration, pipes, filters, comparisons, booleans, defaults, construction, arithmetic, recursive and optional traversal, assignment, deletion, YAML round-tripping, null input, and in-place updates. Rejection tests cover boundaries that could otherwise be misread as supported syntax.
+The advanced fixture covers anchors, collection aliases, merge precedence, block merge lists, directives, expanded tags, scalar types, explicit keys, empty collections, punctuated keys, and document scoping. The expression fixture covers streams, filters, construction, arithmetic, recursion, assignments, maps, entries, variables, dynamic indexes, reducers, deep merge, YAML round-tripping, multi-document updates, and presentation preservation. Rejection tests cover boundaries that could otherwise be misread as supported syntax.
 
 See [`test/advanced.yml`](https://github.com/azohra/yaml.sh/blob/main/test/advanced.yml) and [`test/test.sh`](https://github.com/azohra/yaml.sh/blob/main/test/test.sh).

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -3,24 +3,24 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="A yq-like YAML query tool in one portable shell script. No package manager, language runtime, or downloaded binary.">
+  <meta name="description" content="A yq-like YAML programming tool in one portable shell script. Map, reduce, update, and preserve comments without another runtime.">
   <meta name="theme-color" content="#101410">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="YAML.sh v1 — yq energy. zero baggage.">
-  <meta property="og:description" content="Query YAML with one portable /bin/sh + AWK script. No additional runtime or packages.">
+  <meta property="og:title" content="YAML.sh v2 — yq energy. zero baggage.">
+  <meta property="og:description" content="Program YAML with one portable /bin/sh + AWK script. No additional runtime or packages.">
   <meta property="og:url" content="https://yaml.azohra.com">
   <meta property="og:image" content="https://yaml.azohra.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="YAML.sh v1.2 — yq energy, zero baggage">
+  <meta property="og:image:alt" content="YAML.sh v2 — yq energy, zero baggage">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="YAML.sh v1 — yq energy. zero baggage.">
-  <meta name="twitter:description" content="A yq-like YAML query tool in one portable shell script.">
+  <meta name="twitter:title" content="YAML.sh v2 — yq energy. zero baggage.">
+  <meta name="twitter:description" content="A yq-like YAML programming tool in one portable shell script.">
   <meta name="twitter:image" content="https://yaml.azohra.com/og.png">
   <link rel="canonical" href="https://yaml.azohra.com">
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" href="css/style.css?v=1.2.0">
-  <title>YAML.sh v1 — yq energy. zero baggage.</title>
+  <link rel="stylesheet" href="css/style.css?v=2.0.0">
+  <title>YAML.sh v2 — yq energy. zero baggage.</title>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -29,7 +29,7 @@
     <a class="brand" href="/" aria-label="YAML.sh home">
       <span class="brand-mark">Y</span>
       <span>YAML.sh</span>
-      <span class="version-pill">v1</span>
+      <span class="version-pill">v2</span>
     </a>
     <nav aria-label="Primary navigation">
       <a href="/docs/">Docs</a>
@@ -41,9 +41,9 @@
   <main id="main">
     <section class="hero section-shell">
       <div class="hero-copy">
-        <p class="eyebrow"><span class="status-dot"></span> Version 1.2 · the tiny parser writes back</p>
+        <p class="eyebrow"><span class="status-dot"></span> Version 2 · comments survive the adventure</p>
         <h1>yq energy.<br><span>zero baggage.</span></h1>
-        <p class="hero-lede">Query YAML with one portable shell script. No package manager. No language runtime. No mystery binary. Just <code>/bin/sh</code>, AWK, and a surprising amount of ambition.</p>
+        <p class="hero-lede">Program YAML with one portable shell script. No package manager. No language runtime. No mystery binary. Just <code>/bin/sh</code>, AWK, and a frankly unreasonable amount of ambition.</p>
         <div class="hero-actions">
           <a class="button button-primary" href="#install">Get YAML.sh</a>
           <a class="button button-secondary" href="/docs/">Read the docs <span aria-hidden="true">↗</span></a>
@@ -51,7 +51,7 @@
         <ul class="hero-facts" aria-label="YAML.sh highlights">
           <li><strong>1</strong> file</li>
           <li><strong>0</strong> extra packages</li>
-          <li><strong>57</strong> behavioral tests</li>
+          <li><strong>64</strong> behavioral tests</li>
         </ul>
       </div>
 
@@ -85,7 +85,8 @@
 
     <section class="ticker" aria-label="Core capabilities">
       <div>
-        <span>QUERY + UPDATE</span><b>◆</b>
+        <span>MAP + REDUCE</span><b>◆</b>
+        <span>COMMENTS SURVIVE</span><b>◆</b>
         <span>PIPES + SELECT</span><b>◆</b>
         <span>ANCHORS + ALIASES</span><b>◆</b>
         <span>MERGE KEYS</span><b>◆</b>
@@ -116,8 +117,8 @@
         <span class="pipeline-arrow" aria-hidden="true">→</span>
         <article>
           <span class="step">03</span>
-          <h3>Query</h3>
-          <p>Paths, filters, construction, arithmetic, and assignments operate on real node references without flattening them.</p>
+          <h3>Program</h3>
+          <p>Paths, maps, variables, reducers, arithmetic, and assignments operate on real node references without flattening them.</p>
         </article>
       </div>
     </section>
@@ -129,16 +130,15 @@
       </div>
       <div class="demo-window">
         <div class="demo-tabs" role="tablist" aria-label="CLI examples">
-          <button id="tab-query" role="tab" aria-selected="true" aria-controls="panel-query" data-demo="query">Query</button>
+          <button id="tab-query" role="tab" aria-selected="true" aria-controls="panel-query" data-demo="query">Program</button>
           <button id="tab-json" role="tab" aria-selected="false" aria-controls="panel-json" data-demo="json">JSON</button>
           <button id="tab-merge" role="tab" aria-selected="false" aria-controls="panel-merge" data-demo="merge">Update</button>
           <button id="tab-inspect" role="tab" aria-selected="false" aria-controls="panel-inspect" data-demo="inspect">Inspect</button>
         </div>
         <div class="demo-panel" id="panel-query" role="tabpanel" aria-labelledby="tab-query">
-          <p class="demo-label">Stream, filter, then ask for exactly what you need.</p>
-          <pre><code><span class="prompt">$</span> ysh '.services[] | select(.enabled) | .name' config.yml
-api
-web</code></pre>
+          <p class="demo-label">Stream, map, and reduce without inviting another runtime.</p>
+          <pre><code><span class="prompt">$</span> ysh '.services | map(.name) | unique' config.yml
+["api","worker","web"]</code></pre>
         </div>
         <div class="demo-panel" id="panel-json" role="tabpanel" aria-labelledby="tab-json" hidden>
           <p class="demo-label">Collections become clean, typed JSON.</p>
@@ -146,7 +146,7 @@ web</code></pre>
 {"name":"api","enabled":true,"port":8080}</code></pre>
         </div>
         <div class="demo-panel" id="panel-merge" role="tabpanel" aria-labelledby="tab-merge" hidden>
-          <p class="demo-label">Change a real file in place—no temporary runtime required.</p>
+          <p class="demo-label">Change a real file in place. The comments get to stay.</p>
           <pre><code><span class="prompt">$</span> ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
 
 <span class="prompt">$</span> ysh '.services[].tier' config.yml
@@ -199,12 +199,12 @@ node  1  mapping  line=1</code></pre>
 
     <section class="install section-shell" id="install">
       <div class="install-copy">
-        <p class="kicker">Install v1</p>
+        <p class="kicker">Install v2</p>
         <h2>One pipe.<br>Then go query something.</h2>
         <p>The installer downloads a pinned release and places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
       </div>
       <div class="install-command">
-        <div class="install-command-label"><span>Terminal</span><span>v1.2.0</span></div>
+        <div class="install-command-label"><span>Terminal</span><span>v2.0.0</span></div>
         <pre><code id="install-code">curl -fsSL https://yaml.azohra.com/install | sh</code></pre>
         <button class="copy-button" type="button" data-copy="install-code"><span>Copy command</span><b aria-hidden="true">⌘</b></button>
         <p class="install-note">Prefer to inspect first? <a href="/install">Read the installer source.</a></p>

--- a/_static/_www/install
+++ b/_static/_www/install
@@ -5,6 +5,6 @@ install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.2.0/ysh -o "${temporary_file}"
+curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v2.0.0/ysh -o "${temporary_file}"
 mkdir -p "${install_dir}"
 install -m 755 "${temporary_file}" "${install_dir}/ysh"

--- a/src/ysh.awk
+++ b/src/ysh.awk
@@ -2977,10 +2977,15 @@ function presentation_comment_position(value,    i, char, previous, quote, escap
     return 0
 }
 
-function presentation_plain_safe(value,    lowered) {
+function presentation_plain_safe(value,    lowered, i) {
     lowered = tolower(value)
-    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/ || value ~ /[:#\[\]{},&*!|>@`]/) {
+    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/) {
         return 0
+    }
+    for (i = 1; i <= length(value); i++) {
+        if (index(":#[]{},&*!|>@`", substr(value, i, 1))) {
+            return 0
+        }
     }
     if (lowered == "null" || lowered == "true" || lowered == "false" || value == "~") {
         return 0

--- a/src/ysh.awk
+++ b/src/ysh.awk
@@ -35,7 +35,29 @@ function json_quote(value) {
     return "\"" json_escape(value) "\""
 }
 
-function decode_double_quoted(value,    result, i, char, next_char) {
+function unicode_utf8(codepoint,    first, second, third, fourth) {
+    if (codepoint <= 127) {
+        return sprintf("%c", codepoint)
+    }
+    if (codepoint <= 2047) {
+        first = 192 + int(codepoint / 64)
+        second = 128 + (codepoint % 64)
+        return sprintf("%c%c", first, second)
+    }
+    if (codepoint <= 65535) {
+        first = 224 + int(codepoint / 4096)
+        second = 128 + int((codepoint % 4096) / 64)
+        third = 128 + (codepoint % 64)
+        return sprintf("%c%c%c", first, second, third)
+    }
+    first = 240 + int(codepoint / 262144)
+    second = 128 + int((codepoint % 262144) / 4096)
+    third = 128 + int((codepoint % 4096) / 64)
+    fourth = 128 + (codepoint % 64)
+    return sprintf("%c%c%c%c", first, second, third, fourth)
+}
+
+function decode_double_quoted(value,    result, i, char, next_char, digits, count, codepoint) {
     result = ""
     for (i = 1; i <= length(value); i++) {
         char = substr(value, i, 1)
@@ -57,6 +79,18 @@ function decode_double_quoted(value,    result, i, char, next_char) {
             result = result sprintf("%c", 12)
         } else if (next_char == "/" || next_char == "\\" || next_char == "\"") {
             result = result next_char
+        } else if (next_char == "u" || next_char == "U") {
+            count = next_char == "u" ? 4 : 8
+            digits = substr(value, i + 1, count)
+            if (length(digits) != count || digits !~ /^[0-9a-fA-F]+$/) {
+                fail("invalid Unicode escape on line " NR)
+            }
+            codepoint = base_integer(digits, 16) + 0
+            if (codepoint > 1114111 || (codepoint >= 55296 && codepoint <= 57343)) {
+                fail("invalid Unicode code point on line " NR)
+            }
+            result = result unicode_utf8(codepoint)
+            i += count
         } else {
             result = result "\\" next_char
         }
@@ -472,7 +506,7 @@ function parse_value(value, source_line, indent, allow_block,    cleaned, remain
         bind_anchor(anchor, node, source_line)
         return node
     }
-    if (allow_block && remainder ~ /^[|>][-+0-9]*$/) {
+    if (allow_block && remainder ~ /^[|>]([-+]?[1-9]?|[1-9][-+]?)$/) {
         node = new_node("scalar", source_line, "", "string", tag)
         bind_anchor(anchor, node, source_line)
         start_block(node, remainder, indent, source_line)
@@ -524,7 +558,7 @@ function fail_pending_explicit_keys(source_line,    i) {
     }
 }
 
-function start_block(node, indicator, indent, source_line) {
+function start_block(node, indicator, indent, source_line,    digit) {
     block_active = 1
     block_node = node
     block_style = substr(indicator, 1, 1)
@@ -535,7 +569,9 @@ function start_block(node, indicator, indent, source_line) {
         block_chomp = "keep"
     }
     block_base_indent = indent
-    block_content_indent = -1
+    digit = indicator
+    gsub(/[^1-9]/, "", digit)
+    block_content_indent = digit == "" ? -1 : indent + (digit + 0)
     block_count = 0
     block_source_line = source_line
 }
@@ -820,6 +856,45 @@ function process_line(raw, source_line,    indent, text, clean, key_text, separa
     document_has_content[document_index] = 1
 }
 
+function flow_balance(value,    i, char, quote, escaped, braces, brackets, previous) {
+    quote = ""
+    escaped = 0
+    braces = 0
+    brackets = 0
+    for (i = 1; i <= length(value); i++) {
+        char = substr(value, i, 1)
+        previous = i > 1 ? substr(value, i - 1, 1) : ""
+        if (escaped) {
+            escaped = 0
+            continue
+        }
+        if (quote == "\"" && char == "\\") {
+            escaped = 1
+            continue
+        }
+        if (quote != "") {
+            if (char == quote) {
+                quote = ""
+            }
+            continue
+        }
+        if (char == "\"" || char == sprintf("%c", 39)) {
+            quote = char
+        } else if (char == "#" && (i == 1 || previous ~ /[[:space:]]/)) {
+            break
+        } else if (char == "{") {
+            braces++
+        } else if (char == "}") {
+            braces--
+        } else if (char == "[") {
+            brackets++
+        } else if (char == "]") {
+            brackets--
+        }
+    }
+    return braces + brackets
+}
+
 function finalize_nodes(    node) {
     for (node = 1; node <= node_count; node++) {
         if (node_kind[node] == "pending") {
@@ -1075,6 +1150,25 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position++
         return
     }
+    if (char == ";") {
+        expression_token_type = "semicolon"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "$") {
+        start = expression_position + 1
+        expression_position++
+        while (expression_position <= length(expression_source) && expression_is_word_char(substr(expression_source, expression_position, 1))) {
+            expression_position++
+        }
+        if (expression_position == start) {
+            fail("variable names require characters after $")
+        }
+        expression_token_type = "variable"
+        expression_token_value = substr(expression_source, start, expression_position - start)
+        return
+    }
     if (char == "+" || char == "-" || char == "*" || char == "/" || char == "%") {
         expression_token_type = "arithmetic"
         expression_token_value = char
@@ -1137,7 +1231,7 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         }
         word = substr(expression_source, start, expression_position - start)
         lowered = tolower(word)
-        if (lowered == "and" || lowered == "or" || lowered == "not") {
+        if (lowered == "and" || lowered == "or" || lowered == "not" || lowered == "as") {
             expression_token_type = lowered
         } else if (lowered == "true" || lowered == "false" || lowered == "null") {
             expression_token_type = "literal_" lowered
@@ -1167,7 +1261,7 @@ function expression_expect(type,    actual) {
     expression_lex_next()
 }
 
-function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key) {
+function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key, source, initial, update, variable) {
     if (expression_token_type == "dot") {
         expression = expression_new("identity", 0, 0, "")
         expression_lex_next()
@@ -1199,9 +1293,12 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         expression = expression_new("literal", 0, 0, "")
         expression_literal_type[expression] = "null"
         expression_lex_next()
+    } else if (expression_token_type == "variable") {
+        expression = expression_new("variable", 0, 0, expression_token_value)
+        expression_lex_next()
     } else if (expression_token_type == "left_parenthesis") {
         expression_lex_next()
-        expression = expression_parse_pipe()
+        expression = expression_parse_stream()
         expression_expect("right_parenthesis")
     } else if (expression_token_type == "left_bracket") {
         expression = expression_new("array", 0, 0, "")
@@ -1241,12 +1338,29 @@ function expression_parse_primary(    expression, name, step, argument, value, v
     } else if (expression_token_type == "identifier") {
         name = tolower(expression_token_value)
         expression_lex_next()
-        if (name == "select" || name == "has" || name == "del") {
+        if (name == "reduce") {
+            source = expression_parse_assignment()
+            expression_expect("as")
+            if (expression_token_type != "variable") {
+                fail("reduce requires a variable after as")
+            }
+            variable = expression_token_value
+            expression_lex_next()
             expression_expect("left_parenthesis")
-            argument = expression_parse_pipe()
+            initial = expression_parse_pipe()
+            expression_expect("semicolon")
+            update = expression_parse_pipe()
+            expression_expect("right_parenthesis")
+            expression = expression_new("reduce", source, initial, variable)
+            expression_child[expression, 1] = update
+        } else if (name == "select" || name == "has" || name == "del" || name == "map" || name == "map_values" || name == "with_entries" ||
+            name == "contains" || name == "startswith" || name == "endswith" || name == "split" || name == "join") {
+            expression_expect("left_parenthesis")
+            argument = expression_parse_stream()
             expression_expect("right_parenthesis")
             expression = expression_new(name, argument, 0, "")
-        } else if (name == "length" || name == "keys" || name == "kind" || name == "type") {
+        } else if (name == "length" || name == "keys" || name == "kind" || name == "type" || name == "to_entries" || name == "from_entries" ||
+            name == "sort" || name == "unique" || name == "flatten" || name == "reverse" || name == "upcase" || name == "downcase") {
             if (expression_token_type == "left_parenthesis") {
                 expression_lex_next()
                 expression_expect("right_parenthesis")
@@ -1290,7 +1404,9 @@ function expression_parse_primary(    expression, name, step, argument, value, v
                 expression_expect("right_bracket")
                 expression = expression_new("key", expression, 0, step)
             } else {
-                fail("brackets require an index, quoted key, or empty iterator")
+                step = expression_parse_stream()
+                expression_expect("right_bracket")
+                expression = expression_new("dynamic", expression, step, "")
             }
         } else {
             break
@@ -1397,12 +1513,33 @@ function expression_parse_assignment(    left, right, kind, operator, identity, 
     return left
 }
 
-function expression_parse_pipe(    left, right) {
+function expression_parse_pipe(    left, right, variable) {
     left = expression_parse_assignment()
-    while (expression_token_type == "pipe") {
+    if (expression_token_type == "as") {
         expression_lex_next()
-        right = expression_parse_assignment()
-        left = expression_new("pipe", left, right, "")
+        if (expression_token_type != "variable") {
+            fail("as requires a variable")
+        }
+        variable = expression_token_value
+        expression_lex_next()
+        expression_expect("pipe")
+        right = expression_parse_pipe()
+        return expression_new("bind", left, right, variable)
+    }
+    if (expression_token_type == "pipe") {
+        expression_lex_next()
+        right = expression_parse_pipe()
+        return expression_new("pipe", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_stream(    left, right) {
+    left = expression_parse_pipe()
+    while (expression_token_type == "comma") {
+        expression_lex_next()
+        right = expression_parse_pipe()
+        left = expression_new("comma", left, right, "")
     }
     return left
 }
@@ -1412,7 +1549,7 @@ function expression_parse(source,    expression) {
     expression_position = 1
     expression_count = 0
     expression_lex_next()
-    expression = expression_parse_pipe()
+    expression = expression_parse_stream()
     if (expression_token_type != "end") {
         fail("unexpected token after expression: " expression_token_name(expression_token_type))
     }
@@ -1678,6 +1815,7 @@ function expression_replace_node(target, source,    clone, saved_parent, saved_e
         return target
     }
     clone = expression_clone_node(source)
+    presentation_track_replace(target, clone)
     saved_parent = node_parent[target]
     saved_edge = node_parent_edge[target]
     saved_line = node_line[target]
@@ -1710,6 +1848,9 @@ function expression_replace_node(target, source,    clone, saved_parent, saved_e
 function expression_delete_node(target,    parent, i, j, key, child) {
     if (target in expression_missing_parent && !expression_placeholder_attached[target]) {
         return
+    }
+    if (inplace_mode) {
+        presentation_possible = 0
     }
     parent = node_parent[target]
     if (!parent) {
@@ -1787,6 +1928,31 @@ function expression_arithmetic_number(value, value_type, operator,    rendered) 
     return expression_scalar(rendered, value_type)
 }
 
+function expression_deep_merge(left, right,    left_node, right_node, result, collection, i, key, child, existing, merged) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "mapping" || node_kind[right_node] != "mapping") {
+        return expression_clone_node(right_node)
+    }
+    result = expression_clone_node(left_node)
+    collection = ++collection_serial
+    collect_mapping_keys(right_node, collection)
+    for (i = 1; i <= collection_count[collection]; i++) {
+        key = collection_key[collection, i]
+        child = mapping_lookup(right_node, key)
+        existing = mapping_lookup(result, key)
+        if (!existing) {
+            add_mapping(result, key, expression_clone_node(child), 0, 0)
+        } else if (node_kind[resolve_alias(existing)] == "mapping" && node_kind[resolve_alias(child)] == "mapping") {
+            merged = expression_deep_merge(existing, child)
+            expression_replace_node(existing, merged)
+        } else {
+            expression_replace_node(existing, child)
+        }
+    }
+    return result
+}
+
 function expression_arithmetic(left, right, operator,    left_node, right_node, left_type, right_type, result_type, value, result, i, collection, key, child) {
     left_node = resolve_alias(left)
     right_node = resolve_alias(right)
@@ -1848,10 +2014,120 @@ function expression_arithmetic(left, right, operator,    left_node, right_node, 
         }
         return result
     }
+    if (operator == "*" && node_kind[left_node] == "mapping" && node_kind[right_node] == "mapping") {
+        return expression_deep_merge(left_node, right_node)
+    }
     fail("operator " operator " does not support " expression_type_name(left_node) " and " expression_type_name(right_node))
 }
 
-function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
+function expression_fingerprint(node,    resolved, result, i, collection, key, child, value) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] == "scalar") {
+        value = node_value[resolved]
+        return "s" length(node_type[resolved]) ":" node_type[resolved] length(value) ":" value
+    }
+    if (node_kind[resolved] == "sequence") {
+        result = "q" sequence_count[resolved] ":"
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            value = expression_fingerprint(sequence_child[resolved, i])
+            result = result length(value) ":" value
+        }
+        return result
+    }
+    collection = ++collection_serial
+    collect_mapping_keys(resolved, collection)
+    result = "m" collection_count[collection] ":"
+    for (i = 1; i <= collection_count[collection]; i++) {
+        key = collection_key[collection, i]
+        child = mapping_lookup(resolved, key)
+        value = expression_fingerprint(child)
+        result = result length(key) ":" key length(value) ":" value
+    }
+    return result
+}
+
+function expression_sort_rank(node) {
+    if (node_type[node] == "null") {
+        return 0
+    }
+    if (node_type[node] == "bool") {
+        return 1
+    }
+    if (node_type[node] == "int" || node_type[node] == "float") {
+        return 2
+    }
+    if (node_kind[node] == "scalar") {
+        return 3
+    }
+    if (node_kind[node] == "sequence") {
+        return 4
+    }
+    return 5
+}
+
+function expression_sort_less(left, right,    left_node, right_node, left_rank, right_rank, left_value, right_value) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    left_rank = expression_sort_rank(left_node)
+    right_rank = expression_sort_rank(right_node)
+    if (left_rank != right_rank) {
+        return left_rank < right_rank
+    }
+    if (left_rank == 2) {
+        return expression_numeric(left_node) < expression_numeric(right_node)
+    }
+    if (left_rank <= 3) {
+        left_value = tolower(node_value[left_node])
+        right_value = tolower(node_value[right_node])
+        return left_value < right_value
+    }
+    return expression_fingerprint(left_node) < expression_fingerprint(right_node)
+}
+
+function expression_flatten_into(node, target,    resolved, i) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "sequence") {
+        add_sequence(target, expression_clone_node(resolved), 0)
+        return
+    }
+    for (i = 1; i <= sequence_count[resolved]; i++) {
+        expression_flatten_into(sequence_child[resolved, i], target)
+    }
+}
+
+function expression_string_value(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "scalar") {
+        fail("string operation requires scalar values")
+    }
+    if (node_type[resolved] == "null") {
+        return ""
+    }
+    return node_value[resolved]
+}
+
+function expression_split_string(value, delimiter, result,    position, found) {
+    if (delimiter == "") {
+        for (position = 1; position <= length(value); position++) {
+            add_sequence(result, expression_scalar(substr(value, position, 1), "string"), 0)
+        }
+        return
+    }
+    while ((found = index(value, delimiter))) {
+        add_sequence(result, expression_scalar(substr(value, 1, found - 1), "string"), 0)
+        value = substr(value, found + length(delimiter))
+    }
+    add_sequence(result, expression_scalar(value, "string"), 0)
+}
+
+function expression_entry(key, value, key_type,    entry) {
+    entry = new_node("mapping", 0, "", "", "")
+    add_mapping(entry, "key", expression_scalar(key, key_type), 0, 0)
+    add_mapping(entry, "value", expression_clone_node(value), 0, 0)
+    return entry
+}
+
+function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node, variable, previous, had, accumulator, update_stream) {
     output = expression_stream_new()
     kind = expression_kind[expression]
 
@@ -1862,6 +2138,16 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
     if (kind == "literal") {
         for (i = 1; i <= expression_stream_count[input]; i++) {
             expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "variable") {
+        variable = expression_value[expression]
+        if (!(variable in expression_variable_node)) {
+            fail("undefined variable $" variable)
+        }
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_stream_push(output, expression_variable_node[variable])
         }
         return output
     }
@@ -1922,6 +2208,57 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
         middle = expression_evaluate(expression_left[expression], input)
         return expression_evaluate(expression_right[expression], middle)
     }
+    if (kind == "bind") {
+        variable = expression_value[expression]
+        had = variable in expression_variable_node
+        previous = expression_variable_node[variable]
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                expression_variable_node[variable] = expression_stream_node[left_stream, j]
+                right_stream = expression_evaluate(expression_right[expression], single)
+                expression_stream_append(output, right_stream)
+            }
+        }
+        if (had) {
+            expression_variable_node[variable] = previous
+        } else {
+            delete expression_variable_node[variable]
+        }
+        return output
+    }
+    if (kind == "reduce") {
+        variable = expression_value[expression]
+        had = variable in expression_variable_node
+        previous = expression_variable_node[variable]
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            accumulator = expression_stream_count[right_stream] ? expression_stream_node[right_stream, 1] : expression_null()
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                expression_variable_node[variable] = expression_stream_node[left_stream, j]
+                single = expression_stream_single(accumulator)
+                update_stream = expression_evaluate(expression_child[expression, 1], single)
+                accumulator = expression_stream_count[update_stream] ? expression_stream_node[update_stream, 1] : expression_null()
+            }
+            expression_stream_push(output, accumulator)
+        }
+        if (had) {
+            expression_variable_node[variable] = previous
+        } else {
+            delete expression_variable_node[variable]
+        }
+        return output
+    }
+    if (kind == "comma") {
+        middle = expression_evaluate(expression_left[expression], input)
+        expression_stream_append(output, middle)
+        middle = expression_evaluate(expression_right[expression], input)
+        expression_stream_append(output, middle)
+        return output
+    }
     if (kind == "key" || kind == "index" || kind == "each") {
         middle = expression_evaluate(expression_left[expression], input)
         for (i = 1; i <= expression_stream_count[middle]; i++) {
@@ -1971,6 +2308,43 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                     fail("cannot iterate over " node_type[resolved])
                 }
                 fail("cannot iterate over " node_kind[resolved])
+            }
+        }
+        return output
+    }
+    if (kind == "dynamic") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = expression_stream_node[middle, i]
+            resolved = resolve_alias(node)
+            single = expression_stream_single(resolved)
+            argument_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[argument_stream]; j++) {
+                argument = resolve_alias(expression_stream_node[argument_stream, j])
+                if (node_kind[argument] != "scalar") {
+                    fail("dynamic indexes require a scalar key or index")
+                }
+                if (node_kind[resolved] == "sequence" && node_type[argument] == "int") {
+                    collection = node_value[argument] + 0
+                    if (collection >= 0 && collection < sequence_count[resolved]) {
+                        expression_stream_push(output, sequence_child[resolved, collection + 1])
+                    } else if (!expression_optional[expression]) {
+                        expression_stream_push(output, expression_null())
+                    }
+                } else if (node_kind[resolved] == "mapping") {
+                    key = node_value[argument]
+                    child = mapping_lookup(resolved, key)
+                    if (child) {
+                        expression_stream_push(output, child)
+                    } else if (!expression_optional[expression]) {
+                        child = expression_null()
+                        expression_missing_parent[child] = resolved
+                        expression_missing_key[child] = key
+                        expression_stream_push(output, child)
+                    }
+                } else if (!expression_optional[expression]) {
+                    fail("dynamic indexing requires a mapping or sequence")
+                }
             }
         }
         return output
@@ -2068,6 +2442,205 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
             if (!matched) {
                 right_stream = expression_evaluate(expression_right[expression], single)
                 expression_stream_append(output, right_stream)
+            }
+        }
+        return output
+    }
+    if (kind == "map" || kind == "map_values") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            resolved = resolve_alias(node)
+            if (node_kind[resolved] != "sequence" && node_kind[resolved] != "mapping") {
+                fail(kind " requires a sequence or mapping")
+            }
+            result_node = new_node(kind == "map" ? "sequence" : node_kind[resolved], 0, "", "", "")
+            if (node_kind[resolved] == "sequence") {
+                for (j = 1; j <= sequence_count[resolved]; j++) {
+                    single = expression_stream_single(sequence_child[resolved, j])
+                    argument_stream = expression_evaluate(expression_left[expression], single)
+                    for (collection = 1; collection <= expression_stream_count[argument_stream]; collection++) {
+                        add_sequence(result_node, expression_clone_node(expression_stream_node[argument_stream, collection]), 0)
+                    }
+                }
+            } else {
+                collection = ++collection_serial
+                collect_mapping_keys(resolved, collection)
+                for (j = 1; j <= collection_count[collection]; j++) {
+                    key = collection_key[collection, j]
+                    single = expression_stream_single(mapping_lookup(resolved, key))
+                    argument_stream = expression_evaluate(expression_left[expression], single)
+                    if (kind == "map") {
+                        for (matched = 1; matched <= expression_stream_count[argument_stream]; matched++) {
+                            add_sequence(result_node, expression_clone_node(expression_stream_node[argument_stream, matched]), 0)
+                        }
+                    } else if (expression_stream_count[argument_stream]) {
+                        add_mapping(result_node, key, expression_clone_node(expression_stream_node[argument_stream, 1]), 0, 0)
+                    }
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "to_entries" || kind == "from_entries" || kind == "with_entries") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (kind == "to_entries") {
+                result_node = new_node("sequence", 0, "", "", "")
+                if (node_kind[node] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(node, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        key = collection_key[collection, j]
+                        add_sequence(result_node, expression_entry(key, mapping_lookup(node, key), "string"), 0)
+                    }
+                } else if (node_kind[node] == "sequence") {
+                    for (j = 1; j <= sequence_count[node]; j++) {
+                        add_sequence(result_node, expression_entry((j - 1) "", sequence_child[node, j], "int"), 0)
+                    }
+                } else {
+                    fail("to_entries requires a mapping or sequence")
+                }
+                expression_stream_push(output, result_node)
+                continue
+            }
+            if (kind == "with_entries") {
+                if (node_kind[node] != "mapping" && node_kind[node] != "sequence") {
+                    fail("with_entries requires a mapping or sequence")
+                }
+                middle = expression_stream_new()
+                if (node_kind[node] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(node, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        key = collection_key[collection, j]
+                        single = expression_stream_single(expression_entry(key, mapping_lookup(node, key), "string"))
+                        argument_stream = expression_evaluate(expression_left[expression], single)
+                        expression_stream_append(middle, argument_stream)
+                    }
+                } else {
+                    for (j = 1; j <= sequence_count[node]; j++) {
+                        single = expression_stream_single(expression_entry((j - 1) "", sequence_child[node, j], "int"))
+                        argument_stream = expression_evaluate(expression_left[expression], single)
+                        expression_stream_append(middle, argument_stream)
+                    }
+                }
+            } else {
+                if (node_kind[node] != "sequence") {
+                    fail("from_entries requires a sequence")
+                }
+                middle = expression_stream_new()
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    expression_stream_push(middle, sequence_child[node, j])
+                }
+            }
+            result_node = new_node("mapping", 0, "", "", "")
+            for (j = 1; j <= expression_stream_count[middle]; j++) {
+                child = resolve_alias(expression_stream_node[middle, j])
+                if (node_kind[child] != "mapping" || !mapping_lookup(child, "key") || !mapping_lookup(child, "value")) {
+                    fail(kind " requires entries containing key and value")
+                }
+                key = expression_string_value(mapping_lookup(child, "key"))
+                if (mapping_lookup(result_node, key)) {
+                    expression_replace_node(mapping_lookup(result_node, key), mapping_lookup(child, "value"))
+                } else {
+                    add_mapping(result_node, key, expression_clone_node(mapping_lookup(child, "value")), 0, 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "sort" || kind == "unique" || kind == "reverse" || kind == "flatten") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (node_kind[node] != "sequence") {
+                fail(kind " requires a sequence")
+            }
+            result_node = new_node("sequence", 0, "", "", "")
+            if (kind == "flatten") {
+                expression_flatten_into(node, result_node)
+            } else if (kind == "reverse") {
+                for (j = sequence_count[node]; j >= 1; j--) {
+                    add_sequence(result_node, expression_clone_node(sequence_child[node, j]), 0)
+                }
+            } else if (kind == "unique") {
+                middle = ++expression_sort_serial
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    child = sequence_child[node, j]
+                    key = middle SUBSEP expression_fingerprint(child)
+                    if (!(key in expression_unique_seen)) {
+                        expression_unique_seen[key] = 1
+                        add_sequence(result_node, expression_clone_node(child), 0)
+                    }
+                }
+            } else {
+                middle = ++expression_sort_serial
+                matched = 0
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    child = sequence_child[node, j]
+                    collection = ++matched
+                    while (collection > 1 && expression_sort_less(child, expression_sort_node[middle, collection - 1])) {
+                        expression_sort_node[middle, collection] = expression_sort_node[middle, collection - 1]
+                        collection--
+                    }
+                    expression_sort_node[middle, collection] = child
+                }
+                for (j = 1; j <= matched; j++) {
+                    add_sequence(result_node, expression_clone_node(expression_sort_node[middle, j]), 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "upcase" || kind == "downcase") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (node_kind[node] != "scalar" || node_type[node] != "string") {
+                fail(kind " requires a string")
+            }
+            expression_stream_push(output, expression_scalar(kind == "upcase" ? toupper(node_value[node]) : tolower(node_value[node]), "string"))
+        }
+        return output
+    }
+    if (kind == "contains" || kind == "startswith" || kind == "endswith" || kind == "split" || kind == "join") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            single = expression_stream_single(node)
+            argument_stream = expression_evaluate(expression_left[expression], single)
+            if (!expression_stream_count[argument_stream]) {
+                fail(kind " requires an argument")
+            }
+            argument = expression_string_value(expression_stream_node[argument_stream, 1])
+            if (kind == "join") {
+                if (node_kind[node] != "sequence") {
+                    fail("join requires a sequence")
+                }
+                key = ""
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    if (j > 1) {
+                        key = key argument
+                    }
+                    key = key expression_string_value(sequence_child[node, j])
+                }
+                expression_stream_push(output, expression_scalar(key, "string"))
+                continue
+            }
+            if (node_kind[node] != "scalar" || node_type[node] != "string") {
+                fail(kind " requires a string")
+            }
+            key = node_value[node]
+            if (kind == "contains") {
+                expression_stream_push(output, expression_boolean(index(key, argument) > 0))
+            } else if (kind == "startswith") {
+                expression_stream_push(output, expression_boolean(substr(key, 1, length(argument)) == argument))
+            } else if (kind == "endswith") {
+                expression_stream_push(output, expression_boolean(substr(key, length(key) - length(argument) + 1) == argument))
+            } else {
+                result_node = new_node("sequence", 0, "", "", "")
+                expression_split_string(key, argument, result_node)
+                expression_stream_push(output, result_node)
             }
         }
         return output
@@ -2369,6 +2942,164 @@ function emit_yaml(node,    inline, properties) {
     emit_yaml_collection(node, 0)
 }
 
+function presentation_comment_position(value,    i, char, previous, quote, escaped, braces, brackets) {
+    quote = ""
+    escaped = 0
+    braces = 0
+    brackets = 0
+    for (i = 1; i <= length(value); i++) {
+        char = substr(value, i, 1)
+        previous = i > 1 ? substr(value, i - 1, 1) : ""
+        if (quote != "") {
+            if (escaped) {
+                escaped = 0
+            } else if (quote == "\"" && char == "\\") {
+                escaped = 1
+            } else if (char == quote) {
+                quote = ""
+            }
+            continue
+        }
+        if (char == "\"" || char == sprintf("%c", 39)) {
+            quote = char
+        } else if (char == "{") {
+            braces++
+        } else if (char == "}") {
+            braces--
+        } else if (char == "[") {
+            brackets++
+        } else if (char == "]") {
+            brackets--
+        } else if (char == "#" && braces == 0 && brackets == 0 && (i == 1 || previous ~ /[[:space:]]/)) {
+            return i
+        }
+    }
+    return 0
+}
+
+function presentation_plain_safe(value,    lowered) {
+    lowered = tolower(value)
+    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/ || value ~ /[:#\[\]{},&*!|>@`]/) {
+        return 0
+    }
+    if (lowered == "null" || lowered == "true" || lowered == "false" || value == "~") {
+        return 0
+    }
+    if (scalar_type(value, "", value) != "string") {
+        return 0
+    }
+    return 1
+}
+
+function presentation_scalar_text(node, original,    quote, value) {
+    value = node_value[node]
+    if (node_type[node] != "string") {
+        return yaml_scalar_text(node)
+    }
+    original = trim(original)
+    quote = sprintf("%c", 39)
+    if (substr(original, 1, 1) == quote && substr(original, length(original), 1) == quote) {
+        gsub(quote, quote quote, value)
+        return quote value quote
+    }
+    if (substr(original, 1, 1) == "\"") {
+        return json_quote(value)
+    }
+    if (presentation_plain_safe(value)) {
+        return value
+    }
+    return json_quote(value)
+}
+
+function presentation_track_replace(target, source,    line, raw, resolved_source) {
+    if (!inplace_mode || !presentation_possible) {
+        return
+    }
+    resolved_source = resolve_alias(source)
+    line = node_line[target]
+    raw = raw_input_line[line]
+    if ((target in expression_missing_parent) || line < 1 || node_kind[target] != "scalar" || node_kind[resolved_source] != "scalar" ||
+        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || raw ~ /[\[{].*[\]}]/ || raw ~ /:[[:space:]]*[!&]/) {
+        presentation_possible = 0
+        return
+    }
+    if ((line in presentation_line_node) && presentation_line_node[line] != target) {
+        presentation_possible = 0
+        return
+    }
+    presentation_line_node[line] = target
+}
+
+function emit_presented_line(line, node,    raw, indent, text, separator, rest, prefix, leading, comment_at, token, suffix, body, trailing) {
+    raw = raw_input_line[line]
+    sub(/\r$/, "", raw)
+    indent = indentation(raw, line)
+    text = substr(raw, indent + 1)
+    separator = find_top_level_colon(text, 1)
+    if (separator) {
+        prefix = substr(raw, 1, indent + separator)
+        rest = substr(text, separator + 1)
+    } else if (text == "-" || text ~ /^-[[:space:]]/) {
+        prefix = substr(raw, 1, indent + 1)
+        rest = substr(text, 2)
+    } else {
+        prefix = substr(raw, 1, indent)
+        rest = text
+    }
+    leading = rest
+    sub(/[^ ].*$/, "", leading)
+    comment_at = presentation_comment_position(rest)
+    if (comment_at) {
+        token = trim(substr(rest, 1, comment_at - 1))
+        body = substr(rest, length(leading) + 1, comment_at - length(leading) - 1)
+        trailing = body
+        sub(/^.*[^ ]/, "", trailing)
+        if (trailing == "") {
+            trailing = " "
+        }
+        suffix = trailing substr(rest, comment_at)
+    } else {
+        token = trim(rest)
+        suffix = ""
+    }
+    print prefix leading presentation_scalar_text(node, token) suffix
+}
+
+function emit_preserved_input(    line) {
+    for (line = 1; line <= NR; line++) {
+        if (line in presentation_line_node) {
+            emit_presented_line(line, presentation_line_node[line])
+        } else {
+            print raw_input_line[line]
+        }
+    }
+}
+
+function transform_all_documents(query,    document, root, expression, input) {
+    for (document = 0; document <= document_index; document++) {
+        if (!(document in document_root)) {
+            continue
+        }
+        root = document_root[document]
+        expression = expression_parse(query)
+        input = expression_stream_single(root)
+        expression_evaluate(expression, input)
+    }
+}
+
+function emit_all_yaml_documents(    document, emitted) {
+    emitted = 0
+    for (document = 0; document <= document_index; document++) {
+        if (!(document in document_root)) {
+            continue
+        }
+        if (emitted++) {
+            print "---"
+        }
+        emit_yaml(document_root[document])
+    }
+}
+
 function output_ast(document,    node, i) {
     for (node = 1; node <= node_count; node++) {
         if (node_document[node] != document) {
@@ -2505,13 +3236,40 @@ BEGIN {
     if (selected_document == "") {
         selected_document = 0
     }
+    presentation_possible = 1
 }
 
 {
+    raw_input_line[NR] = $0
+    if (block_active) {
+        process_line($0, NR)
+        next
+    }
+    if (multiline_flow_active) {
+        multiline_flow_text = multiline_flow_text " " trim($0)
+        multiline_flow_depth += flow_balance($0)
+        if (multiline_flow_depth <= 0) {
+            process_line(multiline_flow_text, multiline_flow_line)
+            multiline_flow_active = 0
+            multiline_flow_text = ""
+        }
+        next
+    }
+    multiline_flow_depth = flow_balance($0)
+    if (multiline_flow_depth > 0) {
+        multiline_flow_active = 1
+        multiline_flow_line = NR
+        multiline_flow_text = $0
+        next
+    }
     process_line($0, NR)
 }
 
 END {
+    if (!exit_status && multiline_flow_active) {
+        print "Error: unclosed multiline flow collection on line " multiline_flow_line > "/dev/stderr"
+        exit_status = 1
+    }
     if (!exit_status) {
         flush_block()
         for (pending_indent = 0; pending_indent <= max_indent; pending_indent++) {
@@ -2532,16 +3290,13 @@ END {
         validate_aliases()
         validate_merges()
         if (inplace_mode) {
-            document_total = 0
-            for (document_number in document_root) {
-                document_total++
+            transform_all_documents(query)
+            if (presentation_possible) {
+                emit_preserved_input()
+            } else {
+                emit_all_yaml_documents()
             }
-            if (document_total > 1) {
-                print "Error: --inplace does not yet support multi-document streams" > "/dev/stderr"
-                exit_status = 1
-            }
-        }
-        if (!exit_status) {
+        } else {
             output_result(selected_document + 0, query, output_mode)
         }
     }

--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.2.0
+YSH_VERSION=2.0.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER=$(cat src/ysh.awk)
@@ -24,6 +24,7 @@ Examples:
   ysh -o yaml '.release.channel = "stable"' config.yml
   ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
   ysh -n -o yaml '{name: "api", enabled: true}'
+  ysh '.services | map(.name) | unique' config.yml
   ysh ".services | length" config.yml
   ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
@@ -49,10 +50,10 @@ Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY supports yq-style paths, [], .., ?, pipes, select, comparisons,
-boolean operators, // defaults, construction, =, |=, del, length, keys,
-has, kind, and type. Collections are emitted as JSON by default; streams
-emit one result per line. In-place updates are serialized as YAML.
+QUERY supports yq-style paths, streams, variables, dynamic indexes, maps,
+entries, reducers, sorting, strings, arithmetic, construction, assignment,
+deletion, and deep merge. Collections emit JSON by default. In-place scalar
+updates preserve comments and presentation; structural edits emit stable YAML.
 EOF
 }
 

--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -71,7 +71,7 @@ ysh_set_output_mode() {
 
 ysh_run_awk() {
     if [ "$YSH_NULL_INPUT" -eq 1 ]; then
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
@@ -79,14 +79,14 @@ ysh_run_awk() {
             "$YAML_AWK_PARSER" \
             /dev/null
     elif [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
             -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER"
     else
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 testVersion() {
-    assertEquals "v1.2.0" "$(./ysh --version)"
+    assertEquals "v2.0.0" "$(./ysh --version)"
 }
 
 testHelp() {
@@ -197,6 +197,43 @@ testExpressionDeletion() {
     assertEquals '{"owner":"platform","region":"west"}' "$(./ysh --json 'del(.missing) | .metadata' test/expressions.yml)"
 }
 
+testExpressionMapAndCommaStreams() {
+    assertEquals '["api","worker","web"]' "$(./ysh --json '.services | map(.name)' test/expressions.yml)"
+    assertEquals '{"owner":"PLATFORM","region":"WEST"}' "$(./ysh --json '.metadata | map_values(upcase)' test/expressions.yml)"
+    assertEquals "$(printf '%s\n' platform west)" "$(./ysh '.metadata.owner, .metadata.region' test/expressions.yml)"
+}
+
+testExpressionEntries() {
+    assertEquals '[{"key":"owner","value":"platform"},{"key":"region","value":"west"}]' "$(./ysh --json '.metadata | to_entries' test/expressions.yml)"
+    assertEquals '{"owner":"platform","region":"west"}' "$(./ysh --json '.metadata | to_entries | from_entries' test/expressions.yml)"
+    assertEquals '{"owner":"PLATFORM","region":"WEST"}' "$(./ysh --json '.metadata | with_entries(.value |= upcase)' test/expressions.yml)"
+}
+
+testExpressionSequenceAndStringHelpers() {
+    assertEquals '[1,1,2,3]' "$(./ysh -n --json '[3, 1, 2, 1] | sort')"
+    assertEquals '[3,1,2]' "$(./ysh -n --json '[3, 1, 2, 1] | unique')"
+    assertEquals '[1,2,3,4]' "$(./ysh -n --json '[[1, 2], [3, [4]]] | flatten')"
+    assertEquals '["yaml","sh"]' "$(./ysh -n --json '"yaml.sh" | split(".")')"
+    assertEquals '"yaml.sh"' "$(./ysh -n --json '["yaml", "sh"] | join(".")')"
+    assertEquals 'true' "$(./ysh -n --json '"yaml.sh" | startswith("yaml") and endswith(".sh")')"
+}
+
+testExpressionVariablesAndDynamicIndexes() {
+    assertEquals '"platform"' "$(./ysh -n --json '{key: "owner", data: {owner: "platform"}} | .key as $key | .data[$key]')"
+    assertEquals '{"owner":"platform","region":"west"}' "$(./ysh --json '.metadata as $meta | {owner: $meta.owner, region: $meta.region}' test/expressions.yml)"
+}
+
+testExpressionReduceAndDeepMerge() {
+    assertEquals '20170' "$(./ysh --json 'reduce .services[].port as $port (0; . + $port)' test/expressions.yml)"
+    assertEquals '{"a":{"x":1,"y":3,"z":4},"b":1,"c":2}' "$(./ysh -n --json '{a: {x: 1, y: 2}, b: 1} * {a: {y: 3, z: 4}, c: 2}')"
+}
+
+testExpandedYamlSyntax() {
+    assertEquals '"snowman ☃ rocket 🚀"' "$(printf '%s\n' 'unicode: "snowman \u2603 rocket \U0001F680"' | ./ysh --json '.unicode')"
+    assertEquals '["one",{"name":"two","enabled":true},"three"]' "$(printf '%s\n' 'items: [' '  one,' '  {name: two, enabled: true},' '  three' ']' | ./ysh --json '.items')"
+    assertEquals '"hello\nworld"' "$(printf '%s\n' 'message: |2-' '  hello' '  world' | ./ysh --json '.message')"
+}
+
 testYamlOutputRoundTrips() {
     assertEquals '"core"' "$(./ysh -o=yaml '.metadata.owner = "core"' test/expressions.yml | ./ysh --json '.metadata.owner')"
     assertEquals '"web"' "$(./ysh -o=yaml '.' test/expressions.yml | ./ysh --json '.services[2].name')"
@@ -220,17 +257,29 @@ testInplaceUpdate() {
     rm -f "$inplace_file"
 }
 
-testInplaceRejectsMultiDocumentStreamsWithoutChanges() {
+testInplaceTransformsAllDocuments() {
     inplace_file=test/.tmp-inplace-multi-$$.yml
-    original_file=test/.tmp-inplace-original-$$.yml
     cp test/test.yml "$inplace_file"
-    cp test/test.yml "$original_file"
-    result=$(./ysh -i '.key = "changed"' "$inplace_file" 2>&1)
-    assertNotEquals 0 $?
-    assertContains "$result" "does not yet support multi-document streams"
-    cmp "$original_file" "$inplace_file"
+    ./ysh -i '.key = "changed"' "$inplace_file"
     assertEquals 0 $?
-    rm -f "$inplace_file" "$original_file"
+    assertEquals 'changed' "$(./ysh -d 0 '.key' "$inplace_file")"
+    assertEquals 'changed' "$(./ysh -d 1 '.key' "$inplace_file")"
+    assertEquals 'changed' "$(./ysh -d 2 '.key' "$inplace_file")"
+    rm -f "$inplace_file"
+}
+
+testInplacePreservesScalarPresentation() {
+    inplace_file=test/.tmp-inplace-presentation-$$.yml
+    printf '%s\n' '# deployment settings' 'service:' '  name: api      # public name' '  label: "API service"' '  owner: '\''platform team'\''' '  enabled: true' > "$inplace_file"
+    ./ysh -i '.service.name = "worker" | .service.label = "Worker service" | .service.owner = "core team" | .service.enabled = false' "$inplace_file"
+    assertEquals 0 $?
+    result=$(cat "$inplace_file")
+    assertContains "$result" '# deployment settings'
+    assertContains "$result" 'name: worker      # public name'
+    assertContains "$result" 'label: "Worker service"'
+    assertContains "$result" "owner: 'core team'"
+    assertContains "$result" 'enabled: false'
+    rm -f "$inplace_file"
 }
 
 testExpressionErrors() {
@@ -363,9 +412,9 @@ testMalformedYamlIsRejected() {
     assertNotEquals 0 $?
     assertContains "$result" "unknown syntax"
 
-    result=$(printf "%s\n" "items: [one," "  two]" | ./ysh ".items" 2>&1)
+    result=$(printf "%s\n" "items: [one," "  two" | ./ysh ".items" 2>&1)
     assertNotEquals 0 $?
-    assertContains "$result" "multiline or unclosed flow collection"
+    assertContains "$result" "unclosed multiline flow collection"
 }
 
 testQueryErrors() {
@@ -394,12 +443,12 @@ testRunsWithPosixShell() {
 }
 
 testReleaseArtifactsStayInSync() {
-    assertContains "$(cat README.md)" "v1.2.0/ysh"
-    assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.2.0/ysh"
-    assertContains "$(cat _static/_www/install)" "v1.2.0/ysh"
-    assertContains "$(cat _static/_www/index.html)" "Install v1"
-    assertContains "$(cat _static/_www/index.html)" "style.css?v=1.2.0"
-    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.2.0"
+    assertContains "$(cat README.md)" "v2.0.0/ysh"
+    assertContains "$(cat _static/_www/docs/getting-started.md)" "v2.0.0/ysh"
+    assertContains "$(cat _static/_www/install)" "v2.0.0/ysh"
+    assertContains "$(cat _static/_www/index.html)" "Install v2"
+    assertContains "$(cat _static/_www/index.html)" "style.css?v=2.0.0"
+    assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=2.0.0"
     assertContains "$(cat _static/_www/docs/index.html)" "docsify@4/lib/themes/vue.css"
     assertTrue "social preview image must exist" "[ -s _static/_www/og.png ]"
 }

--- a/ysh
+++ b/ysh
@@ -3376,7 +3376,7 @@ ysh_set_output_mode() {
 
 ysh_run_awk() {
     if [ "$YSH_NULL_INPUT" -eq 1 ]; then
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
@@ -3384,14 +3384,14 @@ ysh_run_awk() {
             "$YAML_AWK_PARSER" \
             /dev/null
     elif [ -z "$YSH_INPUT_FILE" ] || [ "$YSH_INPUT_FILE" = "-" ]; then
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \
             -v inplace_mode="$YSH_INPLACE" \
             "$YAML_AWK_PARSER"
     else
-        awk \
+        LC_ALL=C awk \
             -v query="$YSH_QUERY" \
             -v output_mode="$YSH_OUTPUT_MODE" \
             -v selected_document="$YSH_DOCUMENT" \

--- a/ysh
+++ b/ysh
@@ -2983,10 +2983,15 @@ function presentation_comment_position(value,    i, char, previous, quote, escap
     return 0
 }
 
-function presentation_plain_safe(value,    lowered) {
+function presentation_plain_safe(value,    lowered, i) {
     lowered = tolower(value)
-    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/ || value ~ /[:#\[\]{},&*!|>@`]/) {
+    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/) {
         return 0
+    }
+    for (i = 1; i <= length(value); i++) {
+        if (index(":#[]{},&*!|>@`", substr(value, i, 1))) {
+            return 0
+        }
     }
     if (lowered == "null" || lowered == "true" || lowered == "false" || value == "~") {
         return 0

--- a/ysh
+++ b/ysh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.2.0
+YSH_VERSION=2.0.0
 
 # Replaced by the build with the embedded AWK engine.
 YAML_AWK_PARSER='
@@ -41,7 +41,29 @@ function json_quote(value) {
     return "\"" json_escape(value) "\""
 }
 
-function decode_double_quoted(value,    result, i, char, next_char) {
+function unicode_utf8(codepoint,    first, second, third, fourth) {
+    if (codepoint <= 127) {
+        return sprintf("%c", codepoint)
+    }
+    if (codepoint <= 2047) {
+        first = 192 + int(codepoint / 64)
+        second = 128 + (codepoint % 64)
+        return sprintf("%c%c", first, second)
+    }
+    if (codepoint <= 65535) {
+        first = 224 + int(codepoint / 4096)
+        second = 128 + int((codepoint % 4096) / 64)
+        third = 128 + (codepoint % 64)
+        return sprintf("%c%c%c", first, second, third)
+    }
+    first = 240 + int(codepoint / 262144)
+    second = 128 + int((codepoint % 262144) / 4096)
+    third = 128 + int((codepoint % 4096) / 64)
+    fourth = 128 + (codepoint % 64)
+    return sprintf("%c%c%c%c", first, second, third, fourth)
+}
+
+function decode_double_quoted(value,    result, i, char, next_char, digits, count, codepoint) {
     result = ""
     for (i = 1; i <= length(value); i++) {
         char = substr(value, i, 1)
@@ -63,6 +85,18 @@ function decode_double_quoted(value,    result, i, char, next_char) {
             result = result sprintf("%c", 12)
         } else if (next_char == "/" || next_char == "\\" || next_char == "\"") {
             result = result next_char
+        } else if (next_char == "u" || next_char == "U") {
+            count = next_char == "u" ? 4 : 8
+            digits = substr(value, i + 1, count)
+            if (length(digits) != count || digits !~ /^[0-9a-fA-F]+$/) {
+                fail("invalid Unicode escape on line " NR)
+            }
+            codepoint = base_integer(digits, 16) + 0
+            if (codepoint > 1114111 || (codepoint >= 55296 && codepoint <= 57343)) {
+                fail("invalid Unicode code point on line " NR)
+            }
+            result = result unicode_utf8(codepoint)
+            i += count
         } else {
             result = result "\\" next_char
         }
@@ -478,7 +512,7 @@ function parse_value(value, source_line, indent, allow_block,    cleaned, remain
         bind_anchor(anchor, node, source_line)
         return node
     }
-    if (allow_block && remainder ~ /^[|>][-+0-9]*$/) {
+    if (allow_block && remainder ~ /^[|>]([-+]?[1-9]?|[1-9][-+]?)$/) {
         node = new_node("scalar", source_line, "", "string", tag)
         bind_anchor(anchor, node, source_line)
         start_block(node, remainder, indent, source_line)
@@ -530,7 +564,7 @@ function fail_pending_explicit_keys(source_line,    i) {
     }
 }
 
-function start_block(node, indicator, indent, source_line) {
+function start_block(node, indicator, indent, source_line,    digit) {
     block_active = 1
     block_node = node
     block_style = substr(indicator, 1, 1)
@@ -541,7 +575,9 @@ function start_block(node, indicator, indent, source_line) {
         block_chomp = "keep"
     }
     block_base_indent = indent
-    block_content_indent = -1
+    digit = indicator
+    gsub(/[^1-9]/, "", digit)
+    block_content_indent = digit == "" ? -1 : indent + (digit + 0)
     block_count = 0
     block_source_line = source_line
 }
@@ -826,6 +862,45 @@ function process_line(raw, source_line,    indent, text, clean, key_text, separa
     document_has_content[document_index] = 1
 }
 
+function flow_balance(value,    i, char, quote, escaped, braces, brackets, previous) {
+    quote = ""
+    escaped = 0
+    braces = 0
+    brackets = 0
+    for (i = 1; i <= length(value); i++) {
+        char = substr(value, i, 1)
+        previous = i > 1 ? substr(value, i - 1, 1) : ""
+        if (escaped) {
+            escaped = 0
+            continue
+        }
+        if (quote == "\"" && char == "\\") {
+            escaped = 1
+            continue
+        }
+        if (quote != "") {
+            if (char == quote) {
+                quote = ""
+            }
+            continue
+        }
+        if (char == "\"" || char == sprintf("%c", 39)) {
+            quote = char
+        } else if (char == "#" && (i == 1 || previous ~ /[[:space:]]/)) {
+            break
+        } else if (char == "{") {
+            braces++
+        } else if (char == "}") {
+            braces--
+        } else if (char == "[") {
+            brackets++
+        } else if (char == "]") {
+            brackets--
+        }
+    }
+    return braces + brackets
+}
+
 function finalize_nodes(    node) {
     for (node = 1; node <= node_count; node++) {
         if (node_kind[node] == "pending") {
@@ -1081,6 +1156,25 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         expression_position++
         return
     }
+    if (char == ";") {
+        expression_token_type = "semicolon"
+        expression_token_value = char
+        expression_position++
+        return
+    }
+    if (char == "$") {
+        start = expression_position + 1
+        expression_position++
+        while (expression_position <= length(expression_source) && expression_is_word_char(substr(expression_source, expression_position, 1))) {
+            expression_position++
+        }
+        if (expression_position == start) {
+            fail("variable names require characters after $")
+        }
+        expression_token_type = "variable"
+        expression_token_value = substr(expression_source, start, expression_position - start)
+        return
+    }
     if (char == "+" || char == "-" || char == "*" || char == "/" || char == "%") {
         expression_token_type = "arithmetic"
         expression_token_value = char
@@ -1143,7 +1237,7 @@ function expression_lex_next(    char, next_char, start, quote, escaped, word, l
         }
         word = substr(expression_source, start, expression_position - start)
         lowered = tolower(word)
-        if (lowered == "and" || lowered == "or" || lowered == "not") {
+        if (lowered == "and" || lowered == "or" || lowered == "not" || lowered == "as") {
             expression_token_type = lowered
         } else if (lowered == "true" || lowered == "false" || lowered == "null") {
             expression_token_type = "literal_" lowered
@@ -1173,7 +1267,7 @@ function expression_expect(type,    actual) {
     expression_lex_next()
 }
 
-function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key) {
+function expression_parse_primary(    expression, name, step, argument, value, value_type, child, key, source, initial, update, variable) {
     if (expression_token_type == "dot") {
         expression = expression_new("identity", 0, 0, "")
         expression_lex_next()
@@ -1205,9 +1299,12 @@ function expression_parse_primary(    expression, name, step, argument, value, v
         expression = expression_new("literal", 0, 0, "")
         expression_literal_type[expression] = "null"
         expression_lex_next()
+    } else if (expression_token_type == "variable") {
+        expression = expression_new("variable", 0, 0, expression_token_value)
+        expression_lex_next()
     } else if (expression_token_type == "left_parenthesis") {
         expression_lex_next()
-        expression = expression_parse_pipe()
+        expression = expression_parse_stream()
         expression_expect("right_parenthesis")
     } else if (expression_token_type == "left_bracket") {
         expression = expression_new("array", 0, 0, "")
@@ -1247,12 +1344,29 @@ function expression_parse_primary(    expression, name, step, argument, value, v
     } else if (expression_token_type == "identifier") {
         name = tolower(expression_token_value)
         expression_lex_next()
-        if (name == "select" || name == "has" || name == "del") {
+        if (name == "reduce") {
+            source = expression_parse_assignment()
+            expression_expect("as")
+            if (expression_token_type != "variable") {
+                fail("reduce requires a variable after as")
+            }
+            variable = expression_token_value
+            expression_lex_next()
             expression_expect("left_parenthesis")
-            argument = expression_parse_pipe()
+            initial = expression_parse_pipe()
+            expression_expect("semicolon")
+            update = expression_parse_pipe()
+            expression_expect("right_parenthesis")
+            expression = expression_new("reduce", source, initial, variable)
+            expression_child[expression, 1] = update
+        } else if (name == "select" || name == "has" || name == "del" || name == "map" || name == "map_values" || name == "with_entries" ||
+            name == "contains" || name == "startswith" || name == "endswith" || name == "split" || name == "join") {
+            expression_expect("left_parenthesis")
+            argument = expression_parse_stream()
             expression_expect("right_parenthesis")
             expression = expression_new(name, argument, 0, "")
-        } else if (name == "length" || name == "keys" || name == "kind" || name == "type") {
+        } else if (name == "length" || name == "keys" || name == "kind" || name == "type" || name == "to_entries" || name == "from_entries" ||
+            name == "sort" || name == "unique" || name == "flatten" || name == "reverse" || name == "upcase" || name == "downcase") {
             if (expression_token_type == "left_parenthesis") {
                 expression_lex_next()
                 expression_expect("right_parenthesis")
@@ -1296,7 +1410,9 @@ function expression_parse_primary(    expression, name, step, argument, value, v
                 expression_expect("right_bracket")
                 expression = expression_new("key", expression, 0, step)
             } else {
-                fail("brackets require an index, quoted key, or empty iterator")
+                step = expression_parse_stream()
+                expression_expect("right_bracket")
+                expression = expression_new("dynamic", expression, step, "")
             }
         } else {
             break
@@ -1403,12 +1519,33 @@ function expression_parse_assignment(    left, right, kind, operator, identity, 
     return left
 }
 
-function expression_parse_pipe(    left, right) {
+function expression_parse_pipe(    left, right, variable) {
     left = expression_parse_assignment()
-    while (expression_token_type == "pipe") {
+    if (expression_token_type == "as") {
         expression_lex_next()
-        right = expression_parse_assignment()
-        left = expression_new("pipe", left, right, "")
+        if (expression_token_type != "variable") {
+            fail("as requires a variable")
+        }
+        variable = expression_token_value
+        expression_lex_next()
+        expression_expect("pipe")
+        right = expression_parse_pipe()
+        return expression_new("bind", left, right, variable)
+    }
+    if (expression_token_type == "pipe") {
+        expression_lex_next()
+        right = expression_parse_pipe()
+        return expression_new("pipe", left, right, "")
+    }
+    return left
+}
+
+function expression_parse_stream(    left, right) {
+    left = expression_parse_pipe()
+    while (expression_token_type == "comma") {
+        expression_lex_next()
+        right = expression_parse_pipe()
+        left = expression_new("comma", left, right, "")
     }
     return left
 }
@@ -1418,7 +1555,7 @@ function expression_parse(source,    expression) {
     expression_position = 1
     expression_count = 0
     expression_lex_next()
-    expression = expression_parse_pipe()
+    expression = expression_parse_stream()
     if (expression_token_type != "end") {
         fail("unexpected token after expression: " expression_token_name(expression_token_type))
     }
@@ -1684,6 +1821,7 @@ function expression_replace_node(target, source,    clone, saved_parent, saved_e
         return target
     }
     clone = expression_clone_node(source)
+    presentation_track_replace(target, clone)
     saved_parent = node_parent[target]
     saved_edge = node_parent_edge[target]
     saved_line = node_line[target]
@@ -1716,6 +1854,9 @@ function expression_replace_node(target, source,    clone, saved_parent, saved_e
 function expression_delete_node(target,    parent, i, j, key, child) {
     if (target in expression_missing_parent && !expression_placeholder_attached[target]) {
         return
+    }
+    if (inplace_mode) {
+        presentation_possible = 0
     }
     parent = node_parent[target]
     if (!parent) {
@@ -1793,6 +1934,31 @@ function expression_arithmetic_number(value, value_type, operator,    rendered) 
     return expression_scalar(rendered, value_type)
 }
 
+function expression_deep_merge(left, right,    left_node, right_node, result, collection, i, key, child, existing, merged) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    if (node_kind[left_node] != "mapping" || node_kind[right_node] != "mapping") {
+        return expression_clone_node(right_node)
+    }
+    result = expression_clone_node(left_node)
+    collection = ++collection_serial
+    collect_mapping_keys(right_node, collection)
+    for (i = 1; i <= collection_count[collection]; i++) {
+        key = collection_key[collection, i]
+        child = mapping_lookup(right_node, key)
+        existing = mapping_lookup(result, key)
+        if (!existing) {
+            add_mapping(result, key, expression_clone_node(child), 0, 0)
+        } else if (node_kind[resolve_alias(existing)] == "mapping" && node_kind[resolve_alias(child)] == "mapping") {
+            merged = expression_deep_merge(existing, child)
+            expression_replace_node(existing, merged)
+        } else {
+            expression_replace_node(existing, child)
+        }
+    }
+    return result
+}
+
 function expression_arithmetic(left, right, operator,    left_node, right_node, left_type, right_type, result_type, value, result, i, collection, key, child) {
     left_node = resolve_alias(left)
     right_node = resolve_alias(right)
@@ -1854,10 +2020,120 @@ function expression_arithmetic(left, right, operator,    left_node, right_node, 
         }
         return result
     }
+    if (operator == "*" && node_kind[left_node] == "mapping" && node_kind[right_node] == "mapping") {
+        return expression_deep_merge(left_node, right_node)
+    }
     fail("operator " operator " does not support " expression_type_name(left_node) " and " expression_type_name(right_node))
 }
 
-function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node) {
+function expression_fingerprint(node,    resolved, result, i, collection, key, child, value) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] == "scalar") {
+        value = node_value[resolved]
+        return "s" length(node_type[resolved]) ":" node_type[resolved] length(value) ":" value
+    }
+    if (node_kind[resolved] == "sequence") {
+        result = "q" sequence_count[resolved] ":"
+        for (i = 1; i <= sequence_count[resolved]; i++) {
+            value = expression_fingerprint(sequence_child[resolved, i])
+            result = result length(value) ":" value
+        }
+        return result
+    }
+    collection = ++collection_serial
+    collect_mapping_keys(resolved, collection)
+    result = "m" collection_count[collection] ":"
+    for (i = 1; i <= collection_count[collection]; i++) {
+        key = collection_key[collection, i]
+        child = mapping_lookup(resolved, key)
+        value = expression_fingerprint(child)
+        result = result length(key) ":" key length(value) ":" value
+    }
+    return result
+}
+
+function expression_sort_rank(node) {
+    if (node_type[node] == "null") {
+        return 0
+    }
+    if (node_type[node] == "bool") {
+        return 1
+    }
+    if (node_type[node] == "int" || node_type[node] == "float") {
+        return 2
+    }
+    if (node_kind[node] == "scalar") {
+        return 3
+    }
+    if (node_kind[node] == "sequence") {
+        return 4
+    }
+    return 5
+}
+
+function expression_sort_less(left, right,    left_node, right_node, left_rank, right_rank, left_value, right_value) {
+    left_node = resolve_alias(left)
+    right_node = resolve_alias(right)
+    left_rank = expression_sort_rank(left_node)
+    right_rank = expression_sort_rank(right_node)
+    if (left_rank != right_rank) {
+        return left_rank < right_rank
+    }
+    if (left_rank == 2) {
+        return expression_numeric(left_node) < expression_numeric(right_node)
+    }
+    if (left_rank <= 3) {
+        left_value = tolower(node_value[left_node])
+        right_value = tolower(node_value[right_node])
+        return left_value < right_value
+    }
+    return expression_fingerprint(left_node) < expression_fingerprint(right_node)
+}
+
+function expression_flatten_into(node, target,    resolved, i) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "sequence") {
+        add_sequence(target, expression_clone_node(resolved), 0)
+        return
+    }
+    for (i = 1; i <= sequence_count[resolved]; i++) {
+        expression_flatten_into(sequence_child[resolved, i], target)
+    }
+}
+
+function expression_string_value(node,    resolved) {
+    resolved = resolve_alias(node)
+    if (node_kind[resolved] != "scalar") {
+        fail("string operation requires scalar values")
+    }
+    if (node_type[resolved] == "null") {
+        return ""
+    }
+    return node_value[resolved]
+}
+
+function expression_split_string(value, delimiter, result,    position, found) {
+    if (delimiter == "") {
+        for (position = 1; position <= length(value); position++) {
+            add_sequence(result, expression_scalar(substr(value, position, 1), "string"), 0)
+        }
+        return
+    }
+    while ((found = index(value, delimiter))) {
+        add_sequence(result, expression_scalar(substr(value, 1, found - 1), "string"), 0)
+        value = substr(value, found + length(delimiter))
+    }
+    add_sequence(result, expression_scalar(value, "string"), 0)
+}
+
+function expression_entry(key, value, key_type,    entry) {
+    entry = new_node("mapping", 0, "", "", "")
+    add_mapping(entry, "key", expression_scalar(key, key_type), 0, 0)
+    add_mapping(entry, "value", expression_clone_node(value), 0, 0)
+    return entry
+}
+
+function expression_evaluate(expression, input,    output, middle, left_stream, right_stream, single, kind, node, resolved, child, i, j, collection, key, predicate, matched, argument_stream, argument, result_node, variable, previous, had, accumulator, update_stream) {
     output = expression_stream_new()
     kind = expression_kind[expression]
 
@@ -1868,6 +2144,16 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
     if (kind == "literal") {
         for (i = 1; i <= expression_stream_count[input]; i++) {
             expression_stream_push(output, expression_scalar(expression_value[expression], expression_literal_type[expression]))
+        }
+        return output
+    }
+    if (kind == "variable") {
+        variable = expression_value[expression]
+        if (!(variable in expression_variable_node)) {
+            fail("undefined variable $" variable)
+        }
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            expression_stream_push(output, expression_variable_node[variable])
         }
         return output
     }
@@ -1928,6 +2214,57 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
         middle = expression_evaluate(expression_left[expression], input)
         return expression_evaluate(expression_right[expression], middle)
     }
+    if (kind == "bind") {
+        variable = expression_value[expression]
+        had = variable in expression_variable_node
+        previous = expression_variable_node[variable]
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                expression_variable_node[variable] = expression_stream_node[left_stream, j]
+                right_stream = expression_evaluate(expression_right[expression], single)
+                expression_stream_append(output, right_stream)
+            }
+        }
+        if (had) {
+            expression_variable_node[variable] = previous
+        } else {
+            delete expression_variable_node[variable]
+        }
+        return output
+    }
+    if (kind == "reduce") {
+        variable = expression_value[expression]
+        had = variable in expression_variable_node
+        previous = expression_variable_node[variable]
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            single = expression_stream_single(expression_stream_node[input, i])
+            left_stream = expression_evaluate(expression_left[expression], single)
+            right_stream = expression_evaluate(expression_right[expression], single)
+            accumulator = expression_stream_count[right_stream] ? expression_stream_node[right_stream, 1] : expression_null()
+            for (j = 1; j <= expression_stream_count[left_stream]; j++) {
+                expression_variable_node[variable] = expression_stream_node[left_stream, j]
+                single = expression_stream_single(accumulator)
+                update_stream = expression_evaluate(expression_child[expression, 1], single)
+                accumulator = expression_stream_count[update_stream] ? expression_stream_node[update_stream, 1] : expression_null()
+            }
+            expression_stream_push(output, accumulator)
+        }
+        if (had) {
+            expression_variable_node[variable] = previous
+        } else {
+            delete expression_variable_node[variable]
+        }
+        return output
+    }
+    if (kind == "comma") {
+        middle = expression_evaluate(expression_left[expression], input)
+        expression_stream_append(output, middle)
+        middle = expression_evaluate(expression_right[expression], input)
+        expression_stream_append(output, middle)
+        return output
+    }
     if (kind == "key" || kind == "index" || kind == "each") {
         middle = expression_evaluate(expression_left[expression], input)
         for (i = 1; i <= expression_stream_count[middle]; i++) {
@@ -1977,6 +2314,43 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
                     fail("cannot iterate over " node_type[resolved])
                 }
                 fail("cannot iterate over " node_kind[resolved])
+            }
+        }
+        return output
+    }
+    if (kind == "dynamic") {
+        middle = expression_evaluate(expression_left[expression], input)
+        for (i = 1; i <= expression_stream_count[middle]; i++) {
+            node = expression_stream_node[middle, i]
+            resolved = resolve_alias(node)
+            single = expression_stream_single(resolved)
+            argument_stream = expression_evaluate(expression_right[expression], single)
+            for (j = 1; j <= expression_stream_count[argument_stream]; j++) {
+                argument = resolve_alias(expression_stream_node[argument_stream, j])
+                if (node_kind[argument] != "scalar") {
+                    fail("dynamic indexes require a scalar key or index")
+                }
+                if (node_kind[resolved] == "sequence" && node_type[argument] == "int") {
+                    collection = node_value[argument] + 0
+                    if (collection >= 0 && collection < sequence_count[resolved]) {
+                        expression_stream_push(output, sequence_child[resolved, collection + 1])
+                    } else if (!expression_optional[expression]) {
+                        expression_stream_push(output, expression_null())
+                    }
+                } else if (node_kind[resolved] == "mapping") {
+                    key = node_value[argument]
+                    child = mapping_lookup(resolved, key)
+                    if (child) {
+                        expression_stream_push(output, child)
+                    } else if (!expression_optional[expression]) {
+                        child = expression_null()
+                        expression_missing_parent[child] = resolved
+                        expression_missing_key[child] = key
+                        expression_stream_push(output, child)
+                    }
+                } else if (!expression_optional[expression]) {
+                    fail("dynamic indexing requires a mapping or sequence")
+                }
             }
         }
         return output
@@ -2074,6 +2448,205 @@ function expression_evaluate(expression, input,    output, middle, left_stream, 
             if (!matched) {
                 right_stream = expression_evaluate(expression_right[expression], single)
                 expression_stream_append(output, right_stream)
+            }
+        }
+        return output
+    }
+    if (kind == "map" || kind == "map_values") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = expression_stream_node[input, i]
+            resolved = resolve_alias(node)
+            if (node_kind[resolved] != "sequence" && node_kind[resolved] != "mapping") {
+                fail(kind " requires a sequence or mapping")
+            }
+            result_node = new_node(kind == "map" ? "sequence" : node_kind[resolved], 0, "", "", "")
+            if (node_kind[resolved] == "sequence") {
+                for (j = 1; j <= sequence_count[resolved]; j++) {
+                    single = expression_stream_single(sequence_child[resolved, j])
+                    argument_stream = expression_evaluate(expression_left[expression], single)
+                    for (collection = 1; collection <= expression_stream_count[argument_stream]; collection++) {
+                        add_sequence(result_node, expression_clone_node(expression_stream_node[argument_stream, collection]), 0)
+                    }
+                }
+            } else {
+                collection = ++collection_serial
+                collect_mapping_keys(resolved, collection)
+                for (j = 1; j <= collection_count[collection]; j++) {
+                    key = collection_key[collection, j]
+                    single = expression_stream_single(mapping_lookup(resolved, key))
+                    argument_stream = expression_evaluate(expression_left[expression], single)
+                    if (kind == "map") {
+                        for (matched = 1; matched <= expression_stream_count[argument_stream]; matched++) {
+                            add_sequence(result_node, expression_clone_node(expression_stream_node[argument_stream, matched]), 0)
+                        }
+                    } else if (expression_stream_count[argument_stream]) {
+                        add_mapping(result_node, key, expression_clone_node(expression_stream_node[argument_stream, 1]), 0, 0)
+                    }
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "to_entries" || kind == "from_entries" || kind == "with_entries") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (kind == "to_entries") {
+                result_node = new_node("sequence", 0, "", "", "")
+                if (node_kind[node] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(node, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        key = collection_key[collection, j]
+                        add_sequence(result_node, expression_entry(key, mapping_lookup(node, key), "string"), 0)
+                    }
+                } else if (node_kind[node] == "sequence") {
+                    for (j = 1; j <= sequence_count[node]; j++) {
+                        add_sequence(result_node, expression_entry((j - 1) "", sequence_child[node, j], "int"), 0)
+                    }
+                } else {
+                    fail("to_entries requires a mapping or sequence")
+                }
+                expression_stream_push(output, result_node)
+                continue
+            }
+            if (kind == "with_entries") {
+                if (node_kind[node] != "mapping" && node_kind[node] != "sequence") {
+                    fail("with_entries requires a mapping or sequence")
+                }
+                middle = expression_stream_new()
+                if (node_kind[node] == "mapping") {
+                    collection = ++collection_serial
+                    collect_mapping_keys(node, collection)
+                    for (j = 1; j <= collection_count[collection]; j++) {
+                        key = collection_key[collection, j]
+                        single = expression_stream_single(expression_entry(key, mapping_lookup(node, key), "string"))
+                        argument_stream = expression_evaluate(expression_left[expression], single)
+                        expression_stream_append(middle, argument_stream)
+                    }
+                } else {
+                    for (j = 1; j <= sequence_count[node]; j++) {
+                        single = expression_stream_single(expression_entry((j - 1) "", sequence_child[node, j], "int"))
+                        argument_stream = expression_evaluate(expression_left[expression], single)
+                        expression_stream_append(middle, argument_stream)
+                    }
+                }
+            } else {
+                if (node_kind[node] != "sequence") {
+                    fail("from_entries requires a sequence")
+                }
+                middle = expression_stream_new()
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    expression_stream_push(middle, sequence_child[node, j])
+                }
+            }
+            result_node = new_node("mapping", 0, "", "", "")
+            for (j = 1; j <= expression_stream_count[middle]; j++) {
+                child = resolve_alias(expression_stream_node[middle, j])
+                if (node_kind[child] != "mapping" || !mapping_lookup(child, "key") || !mapping_lookup(child, "value")) {
+                    fail(kind " requires entries containing key and value")
+                }
+                key = expression_string_value(mapping_lookup(child, "key"))
+                if (mapping_lookup(result_node, key)) {
+                    expression_replace_node(mapping_lookup(result_node, key), mapping_lookup(child, "value"))
+                } else {
+                    add_mapping(result_node, key, expression_clone_node(mapping_lookup(child, "value")), 0, 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "sort" || kind == "unique" || kind == "reverse" || kind == "flatten") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (node_kind[node] != "sequence") {
+                fail(kind " requires a sequence")
+            }
+            result_node = new_node("sequence", 0, "", "", "")
+            if (kind == "flatten") {
+                expression_flatten_into(node, result_node)
+            } else if (kind == "reverse") {
+                for (j = sequence_count[node]; j >= 1; j--) {
+                    add_sequence(result_node, expression_clone_node(sequence_child[node, j]), 0)
+                }
+            } else if (kind == "unique") {
+                middle = ++expression_sort_serial
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    child = sequence_child[node, j]
+                    key = middle SUBSEP expression_fingerprint(child)
+                    if (!(key in expression_unique_seen)) {
+                        expression_unique_seen[key] = 1
+                        add_sequence(result_node, expression_clone_node(child), 0)
+                    }
+                }
+            } else {
+                middle = ++expression_sort_serial
+                matched = 0
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    child = sequence_child[node, j]
+                    collection = ++matched
+                    while (collection > 1 && expression_sort_less(child, expression_sort_node[middle, collection - 1])) {
+                        expression_sort_node[middle, collection] = expression_sort_node[middle, collection - 1]
+                        collection--
+                    }
+                    expression_sort_node[middle, collection] = child
+                }
+                for (j = 1; j <= matched; j++) {
+                    add_sequence(result_node, expression_clone_node(expression_sort_node[middle, j]), 0)
+                }
+            }
+            expression_stream_push(output, result_node)
+        }
+        return output
+    }
+    if (kind == "upcase" || kind == "downcase") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            if (node_kind[node] != "scalar" || node_type[node] != "string") {
+                fail(kind " requires a string")
+            }
+            expression_stream_push(output, expression_scalar(kind == "upcase" ? toupper(node_value[node]) : tolower(node_value[node]), "string"))
+        }
+        return output
+    }
+    if (kind == "contains" || kind == "startswith" || kind == "endswith" || kind == "split" || kind == "join") {
+        for (i = 1; i <= expression_stream_count[input]; i++) {
+            node = resolve_alias(expression_stream_node[input, i])
+            single = expression_stream_single(node)
+            argument_stream = expression_evaluate(expression_left[expression], single)
+            if (!expression_stream_count[argument_stream]) {
+                fail(kind " requires an argument")
+            }
+            argument = expression_string_value(expression_stream_node[argument_stream, 1])
+            if (kind == "join") {
+                if (node_kind[node] != "sequence") {
+                    fail("join requires a sequence")
+                }
+                key = ""
+                for (j = 1; j <= sequence_count[node]; j++) {
+                    if (j > 1) {
+                        key = key argument
+                    }
+                    key = key expression_string_value(sequence_child[node, j])
+                }
+                expression_stream_push(output, expression_scalar(key, "string"))
+                continue
+            }
+            if (node_kind[node] != "scalar" || node_type[node] != "string") {
+                fail(kind " requires a string")
+            }
+            key = node_value[node]
+            if (kind == "contains") {
+                expression_stream_push(output, expression_boolean(index(key, argument) > 0))
+            } else if (kind == "startswith") {
+                expression_stream_push(output, expression_boolean(substr(key, 1, length(argument)) == argument))
+            } else if (kind == "endswith") {
+                expression_stream_push(output, expression_boolean(substr(key, length(key) - length(argument) + 1) == argument))
+            } else {
+                result_node = new_node("sequence", 0, "", "", "")
+                expression_split_string(key, argument, result_node)
+                expression_stream_push(output, result_node)
             }
         }
         return output
@@ -2375,6 +2948,164 @@ function emit_yaml(node,    inline, properties) {
     emit_yaml_collection(node, 0)
 }
 
+function presentation_comment_position(value,    i, char, previous, quote, escaped, braces, brackets) {
+    quote = ""
+    escaped = 0
+    braces = 0
+    brackets = 0
+    for (i = 1; i <= length(value); i++) {
+        char = substr(value, i, 1)
+        previous = i > 1 ? substr(value, i - 1, 1) : ""
+        if (quote != "") {
+            if (escaped) {
+                escaped = 0
+            } else if (quote == "\"" && char == "\\") {
+                escaped = 1
+            } else if (char == quote) {
+                quote = ""
+            }
+            continue
+        }
+        if (char == "\"" || char == sprintf("%c", 39)) {
+            quote = char
+        } else if (char == "{") {
+            braces++
+        } else if (char == "}") {
+            braces--
+        } else if (char == "[") {
+            brackets++
+        } else if (char == "]") {
+            brackets--
+        } else if (char == "#" && braces == 0 && brackets == 0 && (i == 1 || previous ~ /[[:space:]]/)) {
+            return i
+        }
+    }
+    return 0
+}
+
+function presentation_plain_safe(value,    lowered) {
+    lowered = tolower(value)
+    if (value == "" || value ~ /^[[:space:]]/ || value ~ /[[:space:]]$/ || value ~ /[:#\[\]{},&*!|>@`]/) {
+        return 0
+    }
+    if (lowered == "null" || lowered == "true" || lowered == "false" || value == "~") {
+        return 0
+    }
+    if (scalar_type(value, "", value) != "string") {
+        return 0
+    }
+    return 1
+}
+
+function presentation_scalar_text(node, original,    quote, value) {
+    value = node_value[node]
+    if (node_type[node] != "string") {
+        return yaml_scalar_text(node)
+    }
+    original = trim(original)
+    quote = sprintf("%c", 39)
+    if (substr(original, 1, 1) == quote && substr(original, length(original), 1) == quote) {
+        gsub(quote, quote quote, value)
+        return quote value quote
+    }
+    if (substr(original, 1, 1) == "\"") {
+        return json_quote(value)
+    }
+    if (presentation_plain_safe(value)) {
+        return value
+    }
+    return json_quote(value)
+}
+
+function presentation_track_replace(target, source,    line, raw, resolved_source) {
+    if (!inplace_mode || !presentation_possible) {
+        return
+    }
+    resolved_source = resolve_alias(source)
+    line = node_line[target]
+    raw = raw_input_line[line]
+    if ((target in expression_missing_parent) || line < 1 || node_kind[target] != "scalar" || node_kind[resolved_source] != "scalar" ||
+        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || raw ~ /[\[{].*[\]}]/ || raw ~ /:[[:space:]]*[!&]/) {
+        presentation_possible = 0
+        return
+    }
+    if ((line in presentation_line_node) && presentation_line_node[line] != target) {
+        presentation_possible = 0
+        return
+    }
+    presentation_line_node[line] = target
+}
+
+function emit_presented_line(line, node,    raw, indent, text, separator, rest, prefix, leading, comment_at, token, suffix, body, trailing) {
+    raw = raw_input_line[line]
+    sub(/\r$/, "", raw)
+    indent = indentation(raw, line)
+    text = substr(raw, indent + 1)
+    separator = find_top_level_colon(text, 1)
+    if (separator) {
+        prefix = substr(raw, 1, indent + separator)
+        rest = substr(text, separator + 1)
+    } else if (text == "-" || text ~ /^-[[:space:]]/) {
+        prefix = substr(raw, 1, indent + 1)
+        rest = substr(text, 2)
+    } else {
+        prefix = substr(raw, 1, indent)
+        rest = text
+    }
+    leading = rest
+    sub(/[^ ].*$/, "", leading)
+    comment_at = presentation_comment_position(rest)
+    if (comment_at) {
+        token = trim(substr(rest, 1, comment_at - 1))
+        body = substr(rest, length(leading) + 1, comment_at - length(leading) - 1)
+        trailing = body
+        sub(/^.*[^ ]/, "", trailing)
+        if (trailing == "") {
+            trailing = " "
+        }
+        suffix = trailing substr(rest, comment_at)
+    } else {
+        token = trim(rest)
+        suffix = ""
+    }
+    print prefix leading presentation_scalar_text(node, token) suffix
+}
+
+function emit_preserved_input(    line) {
+    for (line = 1; line <= NR; line++) {
+        if (line in presentation_line_node) {
+            emit_presented_line(line, presentation_line_node[line])
+        } else {
+            print raw_input_line[line]
+        }
+    }
+}
+
+function transform_all_documents(query,    document, root, expression, input) {
+    for (document = 0; document <= document_index; document++) {
+        if (!(document in document_root)) {
+            continue
+        }
+        root = document_root[document]
+        expression = expression_parse(query)
+        input = expression_stream_single(root)
+        expression_evaluate(expression, input)
+    }
+}
+
+function emit_all_yaml_documents(    document, emitted) {
+    emitted = 0
+    for (document = 0; document <= document_index; document++) {
+        if (!(document in document_root)) {
+            continue
+        }
+        if (emitted++) {
+            print "---"
+        }
+        emit_yaml(document_root[document])
+    }
+}
+
 function output_ast(document,    node, i) {
     for (node = 1; node <= node_count; node++) {
         if (node_document[node] != document) {
@@ -2511,13 +3242,40 @@ BEGIN {
     if (selected_document == "") {
         selected_document = 0
     }
+    presentation_possible = 1
 }
 
 {
+    raw_input_line[NR] = $0
+    if (block_active) {
+        process_line($0, NR)
+        next
+    }
+    if (multiline_flow_active) {
+        multiline_flow_text = multiline_flow_text " " trim($0)
+        multiline_flow_depth += flow_balance($0)
+        if (multiline_flow_depth <= 0) {
+            process_line(multiline_flow_text, multiline_flow_line)
+            multiline_flow_active = 0
+            multiline_flow_text = ""
+        }
+        next
+    }
+    multiline_flow_depth = flow_balance($0)
+    if (multiline_flow_depth > 0) {
+        multiline_flow_active = 1
+        multiline_flow_line = NR
+        multiline_flow_text = $0
+        next
+    }
     process_line($0, NR)
 }
 
 END {
+    if (!exit_status && multiline_flow_active) {
+        print "Error: unclosed multiline flow collection on line " multiline_flow_line > "/dev/stderr"
+        exit_status = 1
+    }
     if (!exit_status) {
         flush_block()
         for (pending_indent = 0; pending_indent <= max_indent; pending_indent++) {
@@ -2538,16 +3296,13 @@ END {
         validate_aliases()
         validate_merges()
         if (inplace_mode) {
-            document_total = 0
-            for (document_number in document_root) {
-                document_total++
+            transform_all_documents(query)
+            if (presentation_possible) {
+                emit_preserved_input()
+            } else {
+                emit_all_yaml_documents()
             }
-            if (document_total > 1) {
-                print "Error: --inplace does not yet support multi-document streams" > "/dev/stderr"
-                exit_status = 1
-            }
-        }
-        if (!exit_status) {
+        } else {
             output_result(selected_document + 0, query, output_mode)
         }
     }
@@ -2574,6 +3329,7 @@ Examples:
   ysh -o yaml '.release.channel = "stable"' config.yml
   ysh -i '.services[] | select(.enabled) | .tier = "active"' config.yml
   ysh -n -o yaml '{name: "api", enabled: true}'
+  ysh '.services | map(.name) | unique' config.yml
   ysh ".services | length" config.yml
   ysh ".missing // \"fallback\"" config.yml
   ysh ".[\"key.with.dots\"]" config.yml
@@ -2599,10 +3355,10 @@ Other:
   -V, --version           print the version
   -h, --help              print this help
 
-QUERY supports yq-style paths, [], .., ?, pipes, select, comparisons,
-boolean operators, // defaults, construction, =, |=, del, length, keys,
-has, kind, and type. Collections are emitted as JSON by default; streams
-emit one result per line. In-place updates are serialized as YAML.
+QUERY supports yq-style paths, streams, variables, dynamic indexes, maps,
+entries, reducers, sorting, strings, arithmetic, construction, assignment,
+deletion, and deep merge. Collections emit JSON by default. In-place scalar
+updates preserve comments and presentation; structural edits emit stable YAML.
 EOF
 }
 


### PR DESCRIPTION
## YAML.sh v2

This is the intentionally ambitious release: YAML.sh grows from a writable query tool into a compact YAML programming language while staying one portable `/bin/sh` + AWK file.

### Language

- comma streams, `map`, `map_values`
- entries workflows, sorting, stable uniqueness, reverse, flatten
- string helpers
- lexical variables and dynamic indexes
- `reduce`
- recursive mapping merge

### YAML and editing

- multiline flow collections
- Unicode escapes
- explicit block-scalar indentation
- every document transformed by `-i`
- hybrid presentation preservation for safe scalar edits
- deterministic semantic fallback for structural edits

### Release surface

- rebuilt README, site, and documentation for v2
- version-pinned installer
- explicit supported/unsupported contract
- generated standalone artifact synchronized

### Verification

- `make all`: ShellCheck + 64 behavioral tests
- POSIX shell syntax validation
- representative 30-program JSON differential suite matched yq v4.53.3 byte-for-byte
- local Chrome QA for landing page and docs, with no console errors

The remaining boundaries are documented: YAML.sh is not a complete YAML validator or complete yq implementation. Presentation preservation is deliberately scalar-first; structural changes use semantic YAML.