### PR TITLE
Verify the v1.7 installer checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Version 1.7 makes YAML.sh useful for real configuration composition while keepin
 - The deterministic property gate now covers five families and 12,000 cases; presentation grows to 400 cases; scale grows to 125,000 payload nodes and 1,500 documents.
 - Sparse node metadata, conditional source retention, and single-pass flow detection reduce large-query peak memory by roughly one quarter; the enforced RSS ceiling tightens from 256 MiB to 224 MiB.
 - The shell launcher now has one shared AWK invocation contract, and the repeatable benchmark reports sub-second timing instead of rounding short runs to zero.
+- The hosted installer downloads the release artifact and verifies its pinned SHA-256 digest before writing anything to the install directory.
 - Versioned site, docs, installer, README, and social artwork now identify v1.7 consistently.
 
 ### Known boundaries

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ chmod +x ysh
 sudo mv ysh /usr/local/bin/ysh
 ```
 
-Or let the tiny installer do those three lines:
+Or let the tiny installer download and checksum-verify the pinned release:
 
 ```sh
 curl -fsSL https://yaml.azohra.com/install | sh

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -201,7 +201,7 @@ node  1  mapping  line=1</code></pre>
       <div class="install-copy">
         <p class="kicker">Install v1.7</p>
         <h2>One pipe.<br>Then go query something.</h2>
-        <p>The installer downloads a pinned release and places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
+        <p>The installer downloads and checksum-verifies a pinned release, then places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
       </div>
       <div class="install-command">
         <div class="install-command-label"><span>Terminal</span><span>v1.7.0</span></div>

--- a/_static/_www/install
+++ b/_static/_www/install
@@ -5,6 +5,26 @@ install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-curl -fsSL https://raw.githubusercontent.com/azohra/yaml.sh/v1.7.0/ysh -o "${temporary_file}"
+expected_sha256=b34b2f5e867293e59e78a89c2f2c3b7fa3d25121fb13dc985e059b2e818d410c
+curl -fsSL https://github.com/azohra/yaml.sh/releases/download/v1.7.0/ysh -o "${temporary_file}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256=$(sha256sum "${temporary_file}")
+    actual_sha256=${actual_sha256%% *}
+elif command -v shasum >/dev/null 2>&1; then
+    actual_sha256=$(shasum -a 256 "${temporary_file}")
+    actual_sha256=${actual_sha256%% *}
+elif command -v openssl >/dev/null 2>&1; then
+    actual_sha256=$(openssl dgst -sha256 "${temporary_file}")
+    actual_sha256=${actual_sha256##* }
+else
+    printf '%s\n' 'YAML.sh requires sha256sum, shasum, or openssl to verify the download.' >&2
+    exit 1
+fi
+if [ "${actual_sha256}" != "${expected_sha256}" ]; then
+    printf '%s\n' 'YAML.sh checksum verification failed; refusing to install.' >&2
+    exit 1
+fi
+
 mkdir -p "${install_dir}"
 install -m 755 "${temporary_file}" "${install_dir}/ysh"

--- a/test/test.sh
+++ b/test/test.sh
@@ -700,9 +700,17 @@ testGeneratedDifferentialCorpusStaysInSync() {
 }
 
 testReleaseArtifactsStayInSync() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        release_sha256=$(sha256sum ysh)
+    else
+        release_sha256=$(shasum -a 256 ysh)
+    fi
+    release_sha256=${release_sha256%% *}
     assertContains "$(cat README.md)" "v1.7.0/ysh"
     assertContains "$(cat _static/_www/docs/getting-started.md)" "v1.7.0/ysh"
     assertContains "$(cat _static/_www/install)" "v1.7.0/ysh"
+    assertContains "$(cat _static/_www/install)" "expected_sha256=$release_sha256"
+    assertContains "$(cat _static/_www/install)" "checksum verification failed"
     assertContains "$(cat _static/_www/index.html)" "Install v1.7"
     assertContains "$(cat _static/_www/index.html)" "style.css?v=1.7.0"
     assertContains "$(cat _static/_www/docs/index.html)" "theme.css?v=1.7.0"


### PR DESCRIPTION
## Summary
- download the pinned v1.7.0 release asset
- verify its hardcoded SHA-256 with sha256sum, shasum, or OpenSSL
- refuse installation without a verifier or on mismatch
- enforce installer/artifact digest sync in the release test

## Verification
- make all (84/84)
- live install through sha256sum
- isolated shasum and OpenSSL fallback paths
- no-verifier refusal path