### PR TITLE
Run CI checks according to changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,117 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.scope.outputs.runtime }}
+      docs: ${{ steps.scope.outputs.docs }}
+      docs_portability: ${{ steps.scope.outputs.docs_portability }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Select required checks
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          runtime=false
+          docs=false
+          docs_portability=false
+
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            runtime=true
+            docs=true
+            docs_portability=true
+            printf '%s\n' '(manual run: all checks)' > "$RUNNER_TEMP/changed-files"
+          elif [ -n "$BASE_SHA" ] && git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/changed-files"
+          else
+            git diff-tree --no-commit-id --name-only -r "$HEAD_SHA" > "$RUNNER_TEMP/changed-files"
+          fi
+
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/*|Makefile)
+                runtime=true
+                docs=true
+                docs_portability=true
+                ;;
+              ysh|_static/_www/install)
+                runtime=true
+                docs=true
+                ;;
+              build/docs.sh|build/docs-*.awk|test/docs.sh)
+                docs=true
+                docs_portability=true
+                ;;
+              README.md|CHANGELOG.md|VERSIONING.md|_static/*|build/docbuilder.awk)
+                docs=true
+                ;;
+              src/*|build/*|test/*|bench/*|.shellcheckrc)
+                runtime=true
+                ;;
+            esac
+          done < "$RUNNER_TEMP/changed-files"
+
+          {
+            printf 'runtime=%s\n' "$runtime"
+            printf 'docs=%s\n' "$docs"
+            printf 'docs_portability=%s\n' "$docs_portability"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            printf '### CI scope\n\n'
+            printf -- '- Runtime portability: `%s`\n' "$runtime"
+            printf -- '- Site and docs: `%s`\n' "$docs"
+            printf -- '- Docs generator portability: `%s`\n\n' "$docs_portability"
+            printf 'Changed paths:\n```text\n'
+            sed -n '1,100p' "$RUNNER_TEMP/changed-files"
+            printf '```\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  docs:
+    name: Site and docs
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate generated pages, links, and assets
+        run: make docs-check
+      - name: Validate documentation JavaScript
+        run: node --check _static/_www/docs/docs.js
+      - name: Install extra AWK implementations
+        if: needs.changes.outputs.docs_portability == 'true'
+        run: sudo apt-get update && sudo apt-get install -y busybox gawk original-awk
+      - name: Validate docs with BusyBox AWK
+        if: needs.changes.outputs.docs_portability == 'true'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ysh-busybox"
+          ln -s "$(command -v busybox)" "${RUNNER_TEMP}/ysh-busybox/awk"
+          PATH="${RUNNER_TEMP}/ysh-busybox:${PATH}" make docs-check
+      - name: Validate docs with POSIX gawk
+        if: needs.changes.outputs.docs_portability == 'true'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ysh-gawk-posix"
+          printf '%s\n' '#!/bin/sh' 'exec gawk --posix "$@"' > "${RUNNER_TEMP}/ysh-gawk-posix/awk"
+          chmod 755 "${RUNNER_TEMP}/ysh-gawk-posix/awk"
+          PATH="${RUNNER_TEMP}/ysh-gawk-posix:${PATH}" make docs-check
+      - name: Validate docs with original AWK
+        if: needs.changes.outputs.docs_portability == 'true'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ysh-original-awk"
+          ln -s "$(command -v original-awk)" "${RUNNER_TEMP}/ysh-original-awk/awk"
+          PATH="${RUNNER_TEMP}/ysh-original-awk:${PATH}" make docs-check
+
   test:
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -19,41 +129,41 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - name: Install Linux portability tools
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y busybox shellcheck
-      - name: Install extra AWK implementations
+      - name: Install portability tools
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y gawk original-awk
-      - name: Install ShellCheck on macOS
-        if: runner.os == 'macOS'
-        run: brew install shellcheck
-      - name: Build, lint, and test
-        run: make all
+        run: sudo apt-get update && sudo apt-get install -y busybox gawk original-awk shellcheck
+      - name: Build and test
+        run: make ysh test
+      - name: Lint
+        if: matrix.os == 'ubuntu-latest'
+        run: make lint
       - name: Validate POSIX shell syntax
         run: sh -n ysh
       - name: Test with BusyBox AWK
-        if: runner.os == 'Linux'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir -p "${RUNNER_TEMP}/ysh-busybox"
           ln -s "$(command -v busybox)" "${RUNNER_TEMP}/ysh-busybox/awk"
-          PATH="${RUNNER_TEMP}/ysh-busybox:${PATH}" make test docs-check
+          PATH="${RUNNER_TEMP}/ysh-busybox:${PATH}" make test
       - name: Test with POSIX gawk
         if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir -p "${RUNNER_TEMP}/ysh-gawk-posix"
           printf '%s\n' '#!/bin/sh' 'exec gawk --posix "$@"' > "${RUNNER_TEMP}/ysh-gawk-posix/awk"
           chmod 755 "${RUNNER_TEMP}/ysh-gawk-posix/awk"
-          PATH="${RUNNER_TEMP}/ysh-gawk-posix:${PATH}" make test docs-check
+          PATH="${RUNNER_TEMP}/ysh-gawk-posix:${PATH}" make test
       - name: Test with original AWK
         if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir -p "${RUNNER_TEMP}/ysh-original-awk"
           ln -s "$(command -v original-awk)" "${RUNNER_TEMP}/ysh-original-awk/awk"
-          PATH="${RUNNER_TEMP}/ysh-original-awk:${PATH}" make test docs-check
-      - name: Test POSIX shell environments
+          PATH="${RUNNER_TEMP}/ysh-original-awk:${PATH}" make test
+      - name: Test common POSIX shell environments
         if: runner.os == 'Linux'
         run: |
           printf '%s\n' 'key: value' | dash ./ysh '.key'
-          printf '%s\n' 'key: value' | busybox sh ./ysh '.key'
           printf '%s\n' 'key: value' | bash --posix ./ysh '.key'
+      - name: Test BusyBox shell
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          printf '%s\n' 'key: value' | busybox sh ./ysh '.key'


### PR DESCRIPTION
## What changed

- classify each diff as runtime, site/docs, or docs-generator work
- run CSS/content/docs changes through one fast site gate
- reserve the four-OS and multi-AWK runtime matrix for parser/runtime changes
- test docs generator changes across mawk, BusyBox, POSIX gawk, and original AWK without rerunning runtime tests
- install ShellCheck once instead of on every platform
- keep manual and CI-definition runs exhaustive

## Validation

- workflow parses as YAML
- `make all`
- workflow changes intentionally exercise every new lane on this PR