### PR TITLE
Publish the YAML.sh story

### DIFF
--- a/_static/_www/css/style.css
+++ b/_static/_www/css/style.css
@@ -616,6 +616,45 @@ h1 span {
   border-top: 1px solid var(--line);
 }
 
+.story-callout {
+  padding-block: 96px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, .9fr);
+  gap: 72px;
+  align-items: end;
+  border-top: 1px solid var(--line);
+}
+
+.story-callout h2 {
+  max-width: 700px;
+  margin: 0;
+  color: var(--paper);
+  font-size: clamp(48px, 6vw, 82px);
+  line-height: .94;
+  letter-spacing: -.065em;
+}
+
+.story-callout > div:last-child > p {
+  margin: 0;
+  color: var(--paper-dim);
+  font-size: 18px;
+}
+
+.story-callout a {
+  margin-top: 28px;
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.story-callout a:hover { color: var(--paper); }
+
 .install-copy > p:last-child {
   max-width: 520px;
   margin-top: 26px;
@@ -736,6 +775,11 @@ footer nav {
   .install {
     grid-template-columns: 1fr;
   }
+
+  .story-callout {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
 }
 
 @media (max-width: 680px) {
@@ -797,6 +841,7 @@ footer nav {
   .architecture,
   .playground,
   .features,
+  .story-callout,
   .install {
     padding-block: 86px;
   }

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -19,7 +19,7 @@
   <meta name="twitter:image" content="https://yaml.azohra.com/og.png">
   <link rel="canonical" href="https://yaml.azohra.com">
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" href="css/style.css?v=3">
+  <link rel="stylesheet" href="css/style.css?v=4">
   <title>YAML.sh — yq energy. zero baggage.</title>
 </head>
 <body>
@@ -32,6 +32,7 @@
       <span class="version-pill" data-ysh-version>v1.8.0</span>
     </a>
     <nav aria-label="Primary navigation">
+      <a href="/story/">Story</a>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
       <a class="nav-cta" href="#install">Install</a>
@@ -197,6 +198,17 @@ node  1  mapping  line=1</code></pre>
       </div>
     </section>
 
+    <section class="story-callout section-shell" aria-labelledby="story-title">
+      <div>
+        <p class="kicker">Field note · August 2026</p>
+        <h2 id="story-title">The YAML parser that got out of hand.</h2>
+      </div>
+      <div>
+        <p>An old Bash experiment became a measured, yq-shaped language in one increasingly unreasonable afternoon. This is the story of the parser we replaced, the evidence that kept raising the goal, and what building it with an agent actually felt like.</p>
+        <a href="/story/">Read the story <span aria-hidden="true">→</span></a>
+      </div>
+    </section>
+
     <section class="install section-shell" id="install">
       <div class="install-copy">
         <p class="kicker">Install the current release</p>
@@ -219,6 +231,7 @@ node  1  mapping  line=1</code></pre>
     </a>
     <p>Made for fun by <a href="https://azohra.com">Azohra</a>. Built in the open.</p>
     <nav aria-label="Footer navigation">
+      <a href="/story/">Story</a>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">Source</a>
       <a href="https://github.com/azohra/yaml.sh/releases">Releases</a>

--- a/_static/_www/story/index.html
+++ b/_static/_www/story/index.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="How an old Bash experiment became a serious one-file YAML processor—and changed how I think about building with agents.">
+  <meta name="theme-color" content="#101410">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="The YAML parser that got out of hand · YAML.sh">
+  <meta property="og:description" content="How an old Bash experiment became a serious one-file YAML processor—and changed how I think about building with agents.">
+  <meta property="og:url" content="https://yaml.azohra.com/story/">
+  <meta property="og:image" content="https://yaml.azohra.com/og.png">
+  <meta property="article:published_time" content="2026-08-02">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The YAML parser that got out of hand · YAML.sh">
+  <meta name="twitter:description" content="An unreasonable shell experiment became a measured, yq-shaped YAML tool.">
+  <meta name="twitter:image" content="https://yaml.azohra.com/og.png">
+  <link rel="canonical" href="https://yaml.azohra.com/story/">
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/css/style.css?v=4">
+  <link rel="stylesheet" href="/story/story.css?v=1">
+  <title>The YAML parser that got out of hand · YAML.sh</title>
+</head>
+<body>
+  <a class="skip-link" href="#story">Skip to story</a>
+
+  <header class="site-header">
+    <a class="brand" href="/" aria-label="YAML.sh home">
+      <span class="brand-mark">Y</span>
+      <span>YAML.sh</span>
+    </a>
+    <nav aria-label="Primary navigation">
+      <a aria-current="page" href="/story/">Story</a>
+      <a href="/docs/">Docs</a>
+      <a href="https://github.com/azohra/yaml.sh">GitHub</a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </nav>
+  </header>
+
+  <main id="story">
+    <header class="story-hero section-shell">
+      <p class="eyebrow"><span class="status-dot"></span> Field note · August 2, 2026</p>
+      <h1>The YAML parser<br> that got <span>out of hand.</span></h1>
+      <p class="story-dek">How an old Bash experiment became a serious one-file YAML processor—and changed how I think about building with agents.</p>
+      <div class="story-meta">
+        <span>Justin Watts</span>
+        <span aria-hidden="true">◆</span>
+        <span>6 minute read</span>
+        <span aria-hidden="true">◆</span>
+        <a href="https://github.com/azohra/yaml.sh/releases/tag/v1.8.0">YAML.sh v1.8</a>
+      </div>
+    </header>
+
+    <div class="story-layout section-shell">
+      <article class="story-body">
+        <div class="story-opening">
+          <p>In 2018, I wrote a YAML parser in Bash. It was funny, useful, and—at the centre—a bad parser design.</p>
+          <p>Frank Vumbaca helped turn the first experiment into something people could actually use. He added blocks, lists, stdin support, documentation, and years of patient fixes. Then the repository mostly sat still. It kept doing its small job while I went on to other things.</p>
+          <p>I came back eight years later intending to do a full audit, close the old issues, replace Travis, rename the default branch, and ship a respectable release. Then I asked Codex a more dangerous question: if we were willing to break the CLI, how much better could this become?</p>
+        </div>
+
+        <section id="useful-stunt">
+          <h2>A useful stunt</h2>
+          <p>The original YAML.sh translated YAML into flattened paths and values. That was a sensible shape for shell scripts: easy to print, easy to grep, and just enough structure to query a configuration file.</p>
+          <p>It was also the ceiling. Once a mapping, sequence, alias, tag, or empty collection had been flattened, important relationships were gone. Every new feature had to reconstruct meaning the parser had already thrown away. Editing YAML without mangling it was almost impossible.</p>
+          <p>I asked whether there was a better parsing design I had missed. There was. The missing idea was not a smarter regular expression. It was an intermediate representation that respected YAML.</p>
+          <p>Version 1 replaced the flattened stream with a node graph. Mappings remain mappings. Sequences remain ordered. Empty collections survive. Tags and source positions stay attached. Anchors and aliases can share identity. Queries and updates operate on nodes instead of guessing their way back from strings.</p>
+          <div class="story-code" aria-label="YAML.sh processing pipeline">
+            <span>The new shape</span>
+            <pre><code>YAML stream → node graph → expression stream → values / YAML</code></pre>
+          </div>
+        </section>
+
+        <section id="permission-to-break-it">
+          <h2>Permission to break it</h2>
+          <p>That change broke the old CLI. I decided that was fine. Compatibility with a clever limitation was less valuable than making the premise useful.</p>
+          <p>We also stopped requiring Bash. The released program is one POSIX shell file with its AWK parser and evaluator embedded. The <code>.sh</code> name still fits: the shell owns the executable, arguments, files, and process behaviour; AWK does the work it is unusually good at. Calling it <code>yaml.awk</code> would describe an implementation detail while hiding the way people actually use it.</p>
+          <p>The goal became precise: yq-shaped configuration work with no runtime dependencies beyond <code>/bin/sh</code> and AWK. Not a miniature clone of every yq feature. Not a standards-compliance trophy. A useful tool for bootstrap scripts, tiny containers, old machines, and the mildly cursed recovery shell where installing the better tool is the problem you are trying to solve.</p>
+          <p>Once that premise was clear, breaking the interface was not reckless. It was the cost of making the product coherent.</p>
+          <blockquote>
+            <p>“The point is to have fun.”</p>
+          </blockquote>
+        </section>
+
+        <section id="estimate-stopped-helping">
+          <h2>The estimate stopped helping</h2>
+          <p>Codex began with estimates that sounded responsible and were consistently wrong. Work described as weeks kept turning into passing tests in minutes. I kept raising the goal. The parser became a query language; the query language gained updates; updates became multi-file workflows; semantic edits learned to preserve the source presentation around them.</p>
+          <p>Speed created its own temptation. At one point we briefly treated a large capability jump as a new major version. I stopped it. More work is not a breaking change, and velocity is not permission for version-number theatre. We corrected the release line and made the version communicate compatibility again.</p>
+          <p>The releases still moved quickly, but each one earned a bounded contract. The sequence mattered more than the spectacle.</p>
+          <ol class="story-timeline" aria-label="Release milestones">
+            <li><strong>v0.3</strong><span>Audit the old tool and make its limits explicit.</span></li>
+            <li><strong>v1.0</strong><span>Replace flattened paths with a proper YAML node graph.</span></li>
+            <li><strong>v1.2</strong><span>Turn queries into writable transformations.</span></li>
+            <li><strong>v1.4</strong><span>Measure compatibility instead of describing it vaguely.</span></li>
+            <li><strong>v1.6</strong><span>Add practical language depth without losing the one-file runtime.</span></li>
+            <li><strong>v1.8</strong><span>Make edits surgical and explain what the tool will preserve.</span></li>
+          </ol>
+        </section>
+
+        <section id="make-it-real">
+          <h2>Make it real</h2>
+          <p>The hard part was not producing more code. The hard part was deciding what evidence would let us believe it.</p>
+          <p>We compared YAML.sh with the official YAML Test Suite and with yq itself. We added real configuration workflows from Kubernetes, Docker Compose, GitHub Actions, GitLab CI, and deployment overlays. We generated expressions, hostile inputs, large documents, deep collections, and presentation-preserving mutations. A supported behaviour needed a test; nearby unsupported behaviour needed an explicit error instead of a confident misparse.</p>
+          <p>That distinction matters. Matching 2,610 categorized yq programs does not mean YAML.sh contains all of yq. Passing 282 expected YAML Test Suite cases does not mean every corner of the YAML specification is implemented. The numbers describe the tested contract. They do not dissolve the boundary around it.</p>
+          <p>By v1.8, that contract was large enough to be useful and specific enough to be trusted.</p>
+          <dl class="story-evidence">
+            <div><dt>yq programs</dt><dd>2,610 / 2,610</dd><dd>in the categorized v1.8 corpus</dd></div>
+            <div><dt>YAML outcomes</dt><dd>282 / 282</dd><dd>expected YAML Test Suite cases</dd></div>
+            <div><dt>generated properties</dt><dd>12,000 / 12,000</dd><dd>grammar-guided checks</dd></div>
+            <div><dt>extra dependencies</dt><dd>0</dd><dd>the runtime is POSIX sh + AWK</dd></div>
+          </dl>
+        </section>
+
+        <section id="agent-loop">
+          <h2>What the agent changed</h2>
+          <p>The surprising part was not that an agent could write AWK quickly. It was how quickly we could turn a claim into a gate, use the failure to find the next missing idea, and repeat.</p>
+          <p>I kept responsibility for the premise. I pushed when the evidence made the estimates obsolete. I pulled us back when the versioning became silly, the documentation started talking too much about the old tool, the brand drifted, or CI spent macOS minutes proving that a web page still rendered. Codex carried an enormous implementation surface without getting bored by the ninety-first invalid fixture.</p>
+          <p>Neither role substitutes for the other. Unbounded generation would have produced an impressive pile. Direction without the implementation pace would have left a very good plan. The useful system was the loop between judgment, code, external comparison, and correction.</p>
+          <p>I have spent much of my career building the first path through ambiguous systems. This felt familiar, only compressed. Make the goal concrete. Build something real. Put it against evidence. Change the plan when the evidence changes. Keep the principle steady.</p>
+        </section>
+
+        <section id="where-it-fits">
+          <h2>Where it fits</h2>
+          <p>YAML.sh is not yq in disguise. yq remains the right answer when you want its complete language, codecs, ecosystem, and mature performance envelope. YAML.sh deliberately leaves out dynamic evaluation, file-loading operators, dates, many codecs, and other capabilities that would weaken its small and inspectable runtime.</p>
+          <p>It is better at a narrower thing: arriving as one readable text file in an environment that already has a shell and AWK. There is no package manager, language runtime, YAML library, or mystery binary. The security model can also be smaller because several powerful classes of behaviour simply do not exist.</p>
+          <p>That is enough of a difference to be a product, not just a stunt. Sometimes yq is exactly right. Sometimes you are writing the script that would install yq.</p>
+        </section>
+
+        <section id="constraint">
+          <h2>The constraint is the fun part</h2>
+          <p>YAML in shell still sounds like a bad idea. I like that. Good constraints create a shape you would not reach by chasing generality, and a little absurdity can provide enough energy to stay with the boring work that makes an idea dependable.</p>
+          <p>The premise survived the rewrite: one file, no dependencies, real YAML work. Everything else was allowed to change.</p>
+          <p>The point was to have fun. The trick was refusing to use fun as an excuse to be sloppy.</p>
+        </section>
+
+        <nav class="story-links" aria-label="Continue exploring YAML.sh">
+          <a href="https://github.com/azohra/yaml.sh"><span>Read the source</span><b aria-hidden="true">↗</b></a>
+          <a href="/docs/yq-compatibility/"><span>Inspect the yq capability map</span><b aria-hidden="true">→</b></a>
+          <a href="/docs/supported_yml/"><span>Read the YAML support contract</span><b aria-hidden="true">→</b></a>
+          <a href="/docs/getting-started/"><span>Install one file</span><b aria-hidden="true">→</b></a>
+        </nav>
+      </article>
+
+      <aside class="story-rail" aria-label="On this page">
+        <a class="story-back" href="/">← YAML.sh</a>
+        <strong>On this page</strong>
+        <ol>
+          <li><a href="#useful-stunt">A useful stunt</a></li>
+          <li><a href="#permission-to-break-it">Permission to break it</a></li>
+          <li><a href="#estimate-stopped-helping">The estimate stopped helping</a></li>
+          <li><a href="#make-it-real">Make it real</a></li>
+          <li><a href="#agent-loop">What the agent changed</a></li>
+          <li><a href="#where-it-fits">Where it fits</a></li>
+          <li><a href="#constraint">The constraint is the fun part</a></li>
+        </ol>
+      </aside>
+    </div>
+  </main>
+
+  <footer>
+    <a class="brand footer-brand" href="/">
+      <span class="brand-mark">Y</span>
+      <span>YAML.sh</span>
+    </a>
+    <p>Made for fun by <a href="https://azohra.com">Azohra</a>. Built in the open.</p>
+    <nav aria-label="Footer navigation">
+      <a href="/docs/">Docs</a>
+      <a href="https://github.com/azohra/yaml.sh">Source</a>
+      <a href="https://github.com/azohra/yaml.sh/releases">Releases</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/_static/_www/story/story.css
+++ b/_static/_www/story/story.css
@@ -1,0 +1,286 @@
+.story-hero {
+  position: relative;
+  padding-block: 110px 96px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.story-hero::after {
+  position: absolute;
+  z-index: -1;
+  right: -8%;
+  bottom: -42%;
+  width: min(580px, 58vw);
+  aspect-ratio: 1;
+  content: "";
+  border: 1px solid rgb(216 255 69 / 18%);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 44px rgb(216 255 69 / 3%),
+    0 0 0 116px rgb(216 255 69 / 2%);
+}
+
+.story-hero h1 {
+  max-width: 980px;
+  font-size: clamp(62px, 9vw, 126px);
+}
+
+.story-dek {
+  max-width: 780px;
+  margin: 42px 0 0;
+  color: var(--paper-dim);
+  font-size: clamp(20px, 2.5vw, 30px);
+  line-height: 1.4;
+  letter-spacing: -.025em;
+}
+
+.story-meta {
+  margin-top: 40px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--sage);
+  font: 700 11px/1.6 var(--mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.story-meta a { color: var(--acid); }
+
+.story-layout {
+  padding-block: 90px 120px;
+  display: grid;
+  grid-template-columns: minmax(0, 760px) minmax(180px, 240px);
+  justify-content: space-between;
+  gap: 84px;
+}
+
+.story-body {
+  min-width: 0;
+  color: var(--paper-dim);
+  font-size: 18px;
+  line-height: 1.82;
+}
+
+.story-opening {
+  padding-bottom: 22px;
+  color: var(--paper);
+  font-size: clamp(21px, 2.2vw, 27px);
+  line-height: 1.62;
+  letter-spacing: -.018em;
+}
+
+.story-body section {
+  padding-top: 70px;
+  scroll-margin-top: 28px;
+}
+
+.story-body h2 {
+  margin: 0 0 28px;
+  color: var(--paper);
+  font-size: clamp(38px, 5vw, 62px);
+  line-height: 1;
+  letter-spacing: -.055em;
+}
+
+.story-body p { margin: 0 0 25px; }
+
+.story-body code {
+  color: var(--acid);
+  font-size: .88em;
+}
+
+.story-code {
+  margin-top: 42px;
+  border: 1px solid rgb(216 255 69 / 32%);
+  background: #0b0e0b;
+}
+
+.story-code > span {
+  padding: 10px 16px;
+  display: block;
+  color: var(--sage);
+  border-bottom: 1px solid var(--line);
+  font: 800 10px/1.4 var(--mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.story-code pre {
+  margin: 0;
+  padding: 24px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+  white-space: pre;
+}
+
+.story-body blockquote {
+  margin: 46px 0 0;
+  padding: 4px 0 4px 28px;
+  border-left: 5px solid var(--acid);
+}
+
+.story-body blockquote p {
+  margin: 0;
+  color: var(--paper);
+  font-size: clamp(34px, 5vw, 56px);
+  font-weight: 840;
+  line-height: 1.04;
+  letter-spacing: -.055em;
+}
+
+.story-timeline {
+  margin: 46px 0 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.story-timeline li {
+  padding: 17px 0;
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.story-timeline strong {
+  color: var(--acid);
+  font: 800 13px/1.7 var(--mono);
+}
+
+.story-timeline span {
+  color: var(--paper-dim);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.story-evidence {
+  margin: 46px 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.story-evidence > div {
+  min-width: 0;
+  padding: 22px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.story-evidence dt {
+  color: var(--sage);
+  font: 800 10px/1.4 var(--mono);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.story-evidence dd { margin: 0; }
+
+.story-evidence dd:nth-of-type(1) {
+  margin-top: 8px;
+  color: var(--paper);
+  font-size: clamp(25px, 3vw, 36px);
+  font-weight: 840;
+  line-height: 1.1;
+  letter-spacing: -.04em;
+}
+
+.story-evidence dd:nth-of-type(2) {
+  margin-top: 7px;
+  color: var(--sage);
+  font: 11px/1.5 var(--mono);
+}
+
+.story-rail {
+  position: sticky;
+  top: 34px;
+  height: fit-content;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+}
+
+.story-back {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--acid);
+  font-size: 12px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.story-rail > strong {
+  margin: 24px 0 12px;
+  display: block;
+  color: var(--sage);
+  font-size: 9px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.story-rail ol {
+  margin: 0;
+  padding: 0 0 0 14px;
+  border-left: 1px solid var(--line);
+  list-style: none;
+}
+
+.story-rail li { margin: 8px 0; }
+
+.story-rail li a {
+  color: var(--sage);
+  font-size: 11px;
+  line-height: 1.45;
+  text-decoration: none;
+}
+
+.story-rail li a:hover { color: var(--acid); }
+
+.story-links {
+  margin-top: 88px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+}
+
+.story-links a {
+  min-height: 72px;
+  padding: 18px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  color: var(--paper);
+  border-bottom: 1px solid var(--line);
+  font: 750 13px/1.5 var(--mono);
+  text-decoration: none;
+}
+
+.story-links a:nth-child(odd) { margin-right: 24px; }
+.story-links a:hover { color: var(--acid); }
+.story-links b { color: var(--acid); }
+
+@media (max-width: 900px) {
+  .story-layout { grid-template-columns: 1fr; gap: 46px; }
+  .story-rail { position: static; order: -1; }
+  .story-rail > strong,
+  .story-rail ol { display: none; }
+}
+
+@media (max-width: 680px) {
+  .story-hero { padding-block: 74px 66px; }
+  .story-hero h1 { font-size: clamp(54px, 16vw, 76px); }
+  .story-dek { margin-top: 30px; font-size: 20px; }
+  .story-layout { padding-block: 44px 86px; }
+  .story-opening { font-size: 20px; }
+  .story-body { font-size: 17px; }
+  .story-body section { padding-top: 56px; }
+  .story-code pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .story-evidence,
+  .story-links { grid-template-columns: 1fr; }
+  .story-links a:nth-child(odd) { margin-right: 0; }
+}

--- a/test/docs.sh
+++ b/test/docs.sh
@@ -4,6 +4,7 @@ set -eu
 
 ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 PUBLISHED=$ROOT/_static/_www/docs
+STORY=$ROOT/_static/_www/story
 GENERATED=$(mktemp -d "${TMPDIR:-/tmp}/ysh-docs.XXXXXX")
 PAGES='getting-started recipes queries documents output yq-compatibility supported_yml security migration internals development versioning'
 trap 'rm -rf "$GENERATED"' 0 1 2 3 15
@@ -55,7 +56,7 @@ if grep -En 'scroll-behavior:[[:space:]]*smooth' "$PUBLISHED/docs.css" >/dev/nul
     exit 1
 fi
 
-for asset in "$ROOT/_static/_www/brand/hero.svg" "$ROOT/_static/_www/og.png" "$PUBLISHED/docs.css" "$PUBLISHED/docs.js"; do
+for asset in "$ROOT/_static/_www/brand/hero.svg" "$ROOT/_static/_www/og.png" "$STORY/story.css" "$PUBLISHED/docs.css" "$PUBLISHED/docs.js"; do
     if [ ! -s "$asset" ]; then
         printf 'Missing documentation asset: %s\n' "$asset" >&2
         exit 1
@@ -63,7 +64,7 @@ for asset in "$ROOT/_static/_www/brand/hero.svg" "$ROOT/_static/_www/og.png" "$P
 done
 
 LINKS=$GENERATED/.links
-for source in "$ROOT/_static/_www/index.html" "$PUBLISHED"/*.html "$PUBLISHED"/*/index.html; do
+for source in "$ROOT/_static/_www/index.html" "$STORY/index.html" "$PUBLISHED"/*.html "$PUBLISHED"/*/index.html; do
     awk -v source="$source" '
     {
         line = $0
@@ -107,7 +108,7 @@ while IFS="	" read -r source link; do
     fi
 done < "$LINKS"
 
-if grep -En 'og-v[0-9]|v[0-9]+\.[0-9]+.*(\.png|\.svg)' "$ROOT/README.md" "$ROOT/_static/_www/index.html" "$PUBLISHED"/*.html "$PUBLISHED"/*/index.html >/dev/null; then
+if grep -En 'og-v[0-9]|v[0-9]+\.[0-9]+.*(\.png|\.svg)' "$ROOT/README.md" "$ROOT/_static/_www/index.html" "$STORY/index.html" "$PUBLISHED"/*.html "$PUBLISHED"/*/index.html >/dev/null; then
     printf '%s\n' 'A release-specific image reference returned.' >&2
     exit 1
 fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -808,7 +808,7 @@ testReleaseArtifactsStayInSync() {
     assertContains "$(cat _static/_www/install)" "expected_sha256=$release_sha256"
     assertContains "$(cat _static/_www/install)" "checksum verification failed"
     assertContains "$(cat _static/_www/index.html)" "data-ysh-version>v1.8.0"
-    assertContains "$(cat _static/_www/index.html)" "css/style.css?v=3"
+    assertContains "$(cat _static/_www/index.html)" "css/style.css?v=4"
     assertNotContains "$(cat _static/_www/index.html)" "class=\"cursor\""
     assertNotContains "$(cat _static/_www/index.html)" "A real parser this time"
     assertNotContains "$(cat _static/_www/css/style.css)" "transform: rotate(1.25deg)"


### PR DESCRIPTION
## Summary

- publishes “The YAML parser that got out of hand” at `/story/`
- adds Story to the YAML.sh homepage navigation, footer, and a dedicated homepage feature
- keeps the page inside the existing YAML.sh black-and-acid visual identity
- extends the static site checks to validate the story’s assets, links, and anchors

## Why

The v1 rebuild deserves a durable first-person account of the parser redesign, the evidence that kept raising the goal, the deliberate boundary beside yq, and what the human-agent collaboration actually contributed.

This is intentionally one project story, not a blog platform or a second documentation system.

## Verification

- `make all` — 90 behavioral tests, 35 real-world workflows, lint, and static documentation checks pass
- visually checked at desktop and 390px mobile
- no horizontal overflow or browser console warnings
- confirmed no `/blog` naming or routes remain