### PR TITLE
Fix BusyBox flow preservation detection

### DIFF
--- a/_static/_www/install
+++ b/_static/_www/install
@@ -5,7 +5,7 @@ install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-expected_sha256=8eca81fb8e0ffd4676d3f2dde9603d2bef5c2a9fb2154fc83a102ce2de95002c
+expected_sha256=7de8eb98d3549e10b5e5b3e508f2f7a7cdf4d0fab851332c98848b4e4361f9b5
 curl -fsSL https://github.com/azohra/yaml.sh/releases/download/v1.11.0/ysh -o "${temporary_file}"
 
 if command -v sha256sum >/dev/null 2>&1; then

--- a/src/ysh.awk
+++ b/src/ysh.awk
@@ -5726,6 +5726,10 @@ function presentation_attached_start(child, lower_bound,    line, raw, indent) {
     return line
 }
 
+function presentation_has_flow_collection(value) {
+    return (index(value, "[") && index(value, "]")) || (index(value, "{") && index(value, "}"))
+}
+
 function presentation_track_sequence_reorder(target, source,    parent, header, raw, text, target_end, serial, i, j, child, origin, found, lower, start, previous_end) {
     if (node_kind[target] != "sequence" || node_kind[source] != "sequence" ||
         sequence_count[target] == 0 || sequence_count[target] != sequence_count[source]) {
@@ -5739,7 +5743,7 @@ function presentation_track_sequence_reorder(target, source,    parent, header, 
     }
     raw = raw_input_line[header]
     text = substr(raw, indentation(raw, header) + 1)
-    if (!find_mapping_separator(text, 1) || text ~ /[\[{].*[\]}]/) {
+    if (!find_mapping_separator(text, 1) || presentation_has_flow_collection(text)) {
         return 0
     }
 
@@ -5802,7 +5806,7 @@ function presentation_track_sequence_append(target, source,    parent, header, f
         return 0
     }
     raw = raw_input_line[header]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         return 0
     }
     for (i = 1; i <= sequence_count[target]; i++) {
@@ -5850,7 +5854,7 @@ function presentation_track_mapping_append(target, source,    first, after, raw,
         return 0
     }
     raw = raw_input_line[first]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         return 0
     }
     indent = indentation(raw, first)
@@ -5894,7 +5898,7 @@ function presentation_track_replace(target, source,    line, raw, resolved_sourc
     line = node_line[target]
     raw = raw_input_line[line]
     if (line < 1 || node_kind[target] != "scalar" || node_kind[resolved_source] != "scalar" ||
-        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || raw ~ /[\[{].*[\]}]/ || raw ~ /:[[:space:]]*[!&]/) {
+        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || presentation_has_flow_collection(raw) || raw ~ /:[[:space:]]*[!&]/) {
         presentation_possible = 0
         return
     }
@@ -5932,7 +5936,7 @@ function presentation_track_insert(target,    parent, key, i, child, first_line,
         return
     }
     raw = raw_input_line[first_line]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         presentation_possible = 0
         return
     }
@@ -6000,7 +6004,7 @@ function presentation_track_delete(target,    parent, line, end, raw, indent, te
     raw = raw_input_line[line]
     indent = indentation(raw, line)
     text = substr(raw, indent + 1)
-    if ((text ~ /^-[[:space:]]+/ && find_top_level_colon(text, 1)) || text ~ /[\[{].*[\]}]/) {
+    if ((text ~ /^-[[:space:]]+/ && find_top_level_colon(text, 1)) || presentation_has_flow_collection(text)) {
         presentation_possible = 0
         return
     }

--- a/test/test.sh
+++ b/test/test.sh
@@ -684,6 +684,7 @@ testPreserveOnlyRefusesRegeneration() {
     preserve_output=test/.tmp-preserve-only-output-$$
     preserve_error=test/.tmp-preserve-only-error-$$
     alias_file=test/.tmp-preserve-only-alias-$$.yml
+    flow_file=test/.tmp-preserve-only-flow-$$.yml
     printf '%s\n' 'service:' '  name: api # keep' '  labels:' '    tier: web' 'items: # keep order' '  - one' 'tail: kept' > "$preserve_file"
     cp "$preserve_file" "$preserve_backup"
 
@@ -713,10 +714,20 @@ testPreserveOnlyRefusesRegeneration() {
     assertContains "$(cat "$preserve_error")" 'preserve-only edit would regenerate YAML presentation'
     assertContains "$(cat "$alias_file")" 'inherited: *defaults'
 
+    printf '%s\n' 'meta: {enabled: false}' 'items: [{name: one, score: 4}]' 'tail: kept' > "$flow_file"
+    ./ysh --preserve-only --diff '.meta.checked = true | .items |= map(.score += 1)' "$flow_file" > "$preserve_output" 2> "$preserve_error"
+    assertEquals 2 $?
+    assertContains "$(cat "$preserve_error")" 'preserve-only edit would regenerate YAML presentation'
+    ./ysh -i '.meta.checked = true | .items |= map(.score += 1)' "$flow_file"
+    assertEquals 0 $?
+    assertEquals '{"enabled":false,"checked":true}' "$(./ysh --json '.meta' "$flow_file")"
+    assertEquals '[{"name":"one","score":5}]' "$(./ysh --json '.items' "$flow_file")"
+    assertEquals kept "$(./ysh '.tail' "$flow_file")"
+
     ./ysh --preserve-only '.service.name = "worker"' "$preserve_file" >/dev/null 2>&1
     assertEquals 2 $?
 
-    rm -f "$alias_file" "$preserve_error" "$preserve_output" "$preserve_backup" "$preserve_file"
+    rm -f "$flow_file" "$alias_file" "$preserve_error" "$preserve_output" "$preserve_backup" "$preserve_file"
 }
 
 testInplaceTransactionRollsBackCommitFailure() {

--- a/ysh
+++ b/ysh
@@ -5733,6 +5733,10 @@ function presentation_attached_start(child, lower_bound,    line, raw, indent) {
     return line
 }
 
+function presentation_has_flow_collection(value) {
+    return (index(value, "[") && index(value, "]")) || (index(value, "{") && index(value, "}"))
+}
+
 function presentation_track_sequence_reorder(target, source,    parent, header, raw, text, target_end, serial, i, j, child, origin, found, lower, start, previous_end) {
     if (node_kind[target] != "sequence" || node_kind[source] != "sequence" ||
         sequence_count[target] == 0 || sequence_count[target] != sequence_count[source]) {
@@ -5746,7 +5750,7 @@ function presentation_track_sequence_reorder(target, source,    parent, header, 
     }
     raw = raw_input_line[header]
     text = substr(raw, indentation(raw, header) + 1)
-    if (!find_mapping_separator(text, 1) || text ~ /[\[{].*[\]}]/) {
+    if (!find_mapping_separator(text, 1) || presentation_has_flow_collection(text)) {
         return 0
     }
 
@@ -5809,7 +5813,7 @@ function presentation_track_sequence_append(target, source,    parent, header, f
         return 0
     }
     raw = raw_input_line[header]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         return 0
     }
     for (i = 1; i <= sequence_count[target]; i++) {
@@ -5857,7 +5861,7 @@ function presentation_track_mapping_append(target, source,    first, after, raw,
         return 0
     }
     raw = raw_input_line[first]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         return 0
     }
     indent = indentation(raw, first)
@@ -5901,7 +5905,7 @@ function presentation_track_replace(target, source,    line, raw, resolved_sourc
     line = node_line[target]
     raw = raw_input_line[line]
     if (line < 1 || node_kind[target] != "scalar" || node_kind[resolved_source] != "scalar" ||
-        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || raw ~ /[\[{].*[\]}]/ || raw ~ /:[[:space:]]*[!&]/) {
+        raw ~ /(^|:[[:space:]]*)[|>][+-]?[[:space:]]*(#|$)/ || presentation_has_flow_collection(raw) || raw ~ /:[[:space:]]*[!&]/) {
         presentation_possible = 0
         return
     }
@@ -5939,7 +5943,7 @@ function presentation_track_insert(target,    parent, key, i, child, first_line,
         return
     }
     raw = raw_input_line[first_line]
-    if (raw ~ /[\[{].*[\]}]/) {
+    if (presentation_has_flow_collection(raw)) {
         presentation_possible = 0
         return
     }
@@ -6007,7 +6011,7 @@ function presentation_track_delete(target,    parent, line, end, raw, indent, te
     raw = raw_input_line[line]
     indent = indentation(raw, line)
     text = substr(raw, indent + 1)
-    if ((text ~ /^-[[:space:]]+/ && find_top_level_colon(text, 1)) || text ~ /[\[{].*[\]}]/) {
+    if ((text ~ /^-[[:space:]]+/ && find_top_level_colon(text, 1)) || presentation_has_flow_collection(text)) {
         presentation_possible = 0
         return
     }


### PR DESCRIPTION
Fixes the BusyBox-only release-evidence failure exposed after the indentless sequence repair.

BusyBox AWK does not interpret the escaped-brace character class used to detect inline flow collections like mawk, gawk, and BSD awk do. Flow input was therefore considered safe for line splicing, producing structurally wrong YAML. The detector now uses portable explicit delimiter checks; strict mode refuses regeneration and normal `-i` regenerates the correct graph.

Evidence:
- exact case 427 replay under BusyBox AWK
- 672-case BusyBox mutation matrix (seed 6)
- 672-case default AWK mutation matrix (seed 6)
- 104 behavioral tests and 35 workflow scenarios
- docs and shell lint