### PR TITLE
Record the release-notes voice

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -34,3 +34,9 @@ Bumping the version touches an exact set:
 3. A dated `CHANGELOG.md` entry plus its compare-link definition at the file tail.
 4. `make docs`, which regenerates the installer checksum, homepage version, and documentation pages.
 5. `make all` and the focused gates for whatever changed.
+
+Release notes carry the voice, not just the facts: the title ends with a
+short per-release quip (never the site tagline), the body opens by showing
+the change — one runnable example beats a paragraph — with one idea per
+bullet, and evidence, changelog, and artifact SHA-256 close in a compact
+footer.


### PR DESCRIPTION
Follow-up to the release-page reformat: writes the format down in VERSIONING.md's release mechanics so future releases keep the voice — quip in the title, show before tell, one idea per bullet, evidence footer. Guidance and docs gates pass.
