### PR TITLE
Add a stable result for conditional CI checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,6 +78,8 @@ jobs:
             printf 'docs_portability=%s\n' "$docs_portability"
           } >> "$GITHUB_OUTPUT"
 
+          # The backticks below are Markdown, not shell substitutions.
+          # shellcheck disable=SC2016
           {
             printf '### CI scope\n\n'
             printf -- '- Runtime portability: `%s`\n' "$runtime"
@@ -131,3 +133,29 @@ jobs:
         with:
           minimum_release_age: 24h
       - run: mise run check:linux-portability
+
+  check:
+    name: Check
+    needs: [changes, docs, test, linux-portability]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          minimum_release_age: 24h
+      - name: Verify selected results
+        env:
+          CLASSIFICATION: ${{ needs.changes.result }}
+          RUNTIME_SCOPE: ${{ needs.changes.outputs.runtime }}
+          DOCS_SCOPE: ${{ needs.changes.outputs.docs }}
+          PORTABILITY_SCOPE: ${{ needs.changes.outputs.docs_portability }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          RUNTIME_RESULT: ${{ needs.test.result }}
+          PORTABILITY_RESULT: ${{ needs.linux-portability.result }}
+        run: |
+          mise run check:ci-result -- "$CLASSIFICATION" "$RUNTIME_SCOPE" "$DOCS_SCOPE" \
+            "$PORTABILITY_SCOPE" "$DOCS_RESULT" "$RUNTIME_RESULT" "$PORTABILITY_RESULT"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,13 @@ agreement with a pinned yq, and the scale and benchmark budgets. It fetches thos
 corpora itself. `mise run evidence:busybox` repeats the conformance, differential,
 and fuzz measurements with BusyBox AWK in Docker. The weekly job runs both verbs.
 
+CI's `Check` job combines the selected runtime, documentation, and portability
+results. It rejects failed classification and missing or unsuccessful selected
+jobs, while accepting intentional skips. Use this stable result for branch
+protection: the runtime matrix emits different check names when skipped.
+
+`mise run push` checks and publishes a clean feature branch for PR review.
+
 ## Generated files
 
 `make ysh` and `make docs` own these paths; edit their sources instead:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ysh: src/ysh.sh $(AWK_MODULES) src/diff.awk Makefile build/shbuilder.awk
 lint: ysh
 	@echo "👖 Linting"
 	@sh -n ysh
+	@shellcheck build/ci-result.sh test/ci-result.sh
 	@shellcheck -e SC2016 ysh build/docs.sh test/docs.sh test/guidance.sh test/test.sh test/workflows.sh test/public-contract.sh test/operator-manifest.sh test/conformance.sh test/toml-conformance.sh test/schema-conformance.sh test/json-patch-conformance.sh test/toml-test-decoder test/toml-test-encoder test/differential.sh test/generate-yq-corpus.sh test/fuzz.sh test/presentation-matrix.sh test/parser-boundaries.sh test/adversarial.sh test/linux-portability-container.sh test/busybox-evidence-container.sh test/fault-bin/mv test/fault-bin/awk bench/benchmark.sh bench/scale.sh _static/_www/install
 
 test: ysh
@@ -22,6 +23,7 @@ test: ysh
 	@./test/workflows.sh
 	@./test/parser-boundaries.sh
 	@./test/public-contract.sh
+	@sh test/ci-result.sh
 
 docs-check: ysh
 	@echo "📚 Checking static documentation"

--- a/build/ci-result.sh
+++ b/build/ci-result.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 7 ]; then
+    echo 'ci-result: expected classification result, three scope flags, and docs/runtime/portability results' >&2
+    exit 1
+fi
+if [ "$1" != success ]; then
+    echo "ci-result: classification did not succeed: $1" >&2
+    exit 1
+fi
+for scope in "$2" "$3" "$4"; do
+    case "$scope" in
+        true|false) ;;
+        *) echo "ci-result: invalid scope: $scope" >&2; exit 1 ;;
+    esac
+done
+
+check_result() {
+    case "$2:$3" in
+        true:success|false:success|false:skipped) ;;
+        *) echo "ci-result: $1 selected=$2 result=$3" >&2; exit 1 ;;
+    esac
+}
+
+portability=false
+if [ "$2" = true ] || [ "$4" = true ]; then
+    portability=true
+fi
+check_result docs "$3" "$5"
+check_result runtime "$2" "$6"
+check_result portability "$portability" "$7"
+echo 'ci-result: all selected checks passed'

--- a/mise.toml
+++ b/mise.toml
@@ -203,6 +203,32 @@ docker run --rm --network none --volume "$dir:/evidence:ro" "$image" ./test/busy
 description = "The Makefile's full battery: build, lint, tests, docs"
 depends = ["check:runtime", "check:docs"]
 
+[tasks."check:ci-result"]
+description = "Verify classified CI jobs succeeded or were intentionally skipped"
+raw_args = true
+run = "sh build/ci-result.sh"
+
+[tasks.push]
+description = "Push a checked feature branch for review"
+tools = { gh = "2.100.0" }
+depends = ["check"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+branch=$(git branch --show-current)
+[ -n "$branch" ] && [ "$branch" != main ] || { echo 'push: use a feature branch' >&2; exit 1; }
+[ -z "$(git status --porcelain)" ] || { echo 'push: commit the complete change first' >&2; exit 1; }
+[ "$(gh api --hostname github.com user --jq .login)" = azohra ] || { echo 'push: expected the azohra account' >&2; exit 1; }
+[ "$(gh api --hostname github.com repos/azohra/yaml.sh --jq '.id == 159573143 and .private == false')" = true ] || { echo 'push: repository identity changed' >&2; exit 1; }
+for url in "$(git remote get-url --all origin)" "$(git remote get-url --push --all origin)"; do
+  case "$url" in
+    https://github.com/azohra/yaml.sh|https://github.com/azohra/yaml.sh.git|git@github.com:azohra/yaml.sh.git) ;;
+    *) echo 'push: unexpected remote destination' >&2; exit 1 ;;
+  esac
+done
+git push --set-upstream origin "refs/heads/$branch:refs/heads/$branch"
+'''
+
 [tasks.deploy]
 description = "Deploy the site at the tip of main"
 confirm = "Deploy yaml.azohra.com to production?"

--- a/test/ci-result.sh
+++ b/test/ci-result.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+testSelectedChecksAndIntentionalSkips() {
+    sh build/ci-result.sh success true true true success success success >/dev/null
+    assertEquals 'mixed changes' 0 "$?"
+    sh build/ci-result.sh success true false false skipped success success >/dev/null
+    assertEquals 'runtime changes' 0 "$?"
+    sh build/ci-result.sh success false true false success skipped skipped >/dev/null
+    assertEquals 'docs-only changes' 0 "$?"
+    sh build/ci-result.sh success false true true success skipped success >/dev/null
+    assertEquals 'docs generator portability' 0 "$?"
+    sh build/ci-result.sh success false false false skipped skipped skipped >/dev/null
+    assertEquals 'unrelated paths' 0 "$?"
+}
+
+testIncompleteOrFailedProofIsRejected() {
+    for result in failure cancelled skipped ''; do
+        sh build/ci-result.sh "$result" false false false skipped skipped skipped >/dev/null 2>&1
+        assertEquals "classification $result" 1 "$?"
+    done
+    for scope in '' unknown; do
+        sh build/ci-result.sh success "$scope" false false skipped skipped skipped >/dev/null 2>&1
+        assertEquals "invalid scope $scope" 1 "$?"
+    done
+    for result in failure cancelled skipped ''; do
+        sh build/ci-result.sh success true true true "$result" success success >/dev/null 2>&1
+        assertEquals "docs $result" 1 "$?"
+        sh build/ci-result.sh success true true true success "$result" success >/dev/null 2>&1
+        assertEquals "runtime $result" 1 "$?"
+        sh build/ci-result.sh success true true true success success "$result" >/dev/null 2>&1
+        assertEquals "portability $result" 1 "$?"
+    done
+    sh build/ci-result.sh success false false false failure skipped skipped >/dev/null 2>&1
+    assertEquals 'an unselected job that ran and failed' 1 "$?"
+    sh build/ci-result.sh >/dev/null 2>&1
+    assertEquals 'missing inputs' 1 "$?"
+}
+
+# shellcheck source=/dev/null
+. ./test/shunit2


### PR DESCRIPTION
The runtime matrix reports four `test (OS)` checks when selected, but only `test` when skipped. Requiring either set of names cannot cover both cases.

Add a stable `Check` result that verifies classification and each selected runtime, docs, and portability job. It accepts intentional skips and rejects failed classification, missing scope data, and unsuccessful selected jobs. The existing classifier and test matrix stay intact.

Keep the result validator in a mise task, exercise its success and failure cases in the shell suite, and provide a checked feature-branch push task. No branch protection is enabled by this PR.

Validation: `mise run check` passes, including 120 runtime tests, the existing workflow/contract/docs suites, and the new result tests. Actionlint passes.
