### PR TITLE
Pin Actions and authenticate mise setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       docs: ${{ steps.scope.outputs.docs }}
       docs_portability: ${{ steps.scope.outputs.docs_portability }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
       - name: Select required checks
@@ -97,8 +97,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
         with:
           minimum_release_age: 24h
       - name: Validate generated pages, links, assets, and docs JavaScript
@@ -114,8 +114,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
         with:
           minimum_release_age: 24h
       - name: Build, lint, and test
@@ -128,8 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
         with:
           minimum_release_age: 24h
       - run: mise run check:linux-portability

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,6 +99,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       - name: Validate generated pages, links, assets, and docs JavaScript
@@ -116,6 +118,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       - name: Build, lint, and test
@@ -130,6 +134,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       - run: mise run check:linux-portability
@@ -145,6 +151,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       - name: Verify selected results

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
         with:
           minimum_release_age: 24h
       - run: mise run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       - run: mise run deploy

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
         with:
           minimum_release_age: 24h
       # The battery, against the pinned corpora it fetches. Identical to what

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
       # The battery, against the pinned corpora it fetches. Identical to what


### PR DESCRIPTION
Pass the workflow token to mise before cached setup so self-update can authenticate in CI. Pin the existing GitHub Actions versions to full commit SHAs. Workflow triggers, job permissions and mise commands retain their existing behaviour.

Validation: `mise run check` and actionlint pass.
