### PR TITLE
Publish verified releases before promoting installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing signed release tag on main
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
+      - id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          sha=$(mise run --quiet release:source -- "$RELEASE_TAG")
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          git checkout --detach "$sha"
+      - name: Build release
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: mise run build:release -- "$RELEASE_TAG"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release
+          path: .release
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: bosun-release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ needs.build.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release
+          path: .release
+      - run: chmod +x .release/ysh
+      - id: bosun
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.BOSUN_CLIENT_ID }}
+          private-key: ${{ secrets.BOSUN_PRIVATE_KEY }}
+          owner: azohra
+          repositories: yaml.sh
+          permission-contents: write
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ steps.bosun.outputs.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: mise run release -- "$RELEASE_TAG"
+
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: deploy
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c
+        env:
+          MISE_GITHUB_TOKEN: ${{ github.token }}
+      - run: mise run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ mise*.lock
 # cloudflare
 .wrangler/
 .evidence/
+
+.release/

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ ysh: src/ysh.sh $(AWK_MODULES) src/diff.awk Makefile build/shbuilder.awk
 lint: ysh
 	@echo "👖 Linting"
 	@sh -n ysh
-	@shellcheck build/ci-result.sh test/ci-result.sh
+	@shellcheck build/ci-result.sh test/ci-result.sh build/release-*.sh test/release.sh
 	@shellcheck -e SC2016 ysh build/docs.sh test/docs.sh test/guidance.sh test/test.sh test/workflows.sh test/public-contract.sh test/operator-manifest.sh test/conformance.sh test/toml-conformance.sh test/schema-conformance.sh test/json-patch-conformance.sh test/toml-test-decoder test/toml-test-encoder test/differential.sh test/generate-yq-corpus.sh test/fuzz.sh test/presentation-matrix.sh test/parser-boundaries.sh test/adversarial.sh test/linux-portability-container.sh test/busybox-evidence-container.sh test/fault-bin/mv test/fault-bin/awk bench/benchmark.sh bench/scale.sh _static/_www/install
 
 test: ysh
+	@bash test/release.sh
 	@echo "🔬 Testing"
 	@./test/test.sh
 	@./test/workflows.sh

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,3 +43,25 @@ short per-release quip (never the site tagline), the body opens by showing
 the change — one runnable example beats a paragraph — with one idea per
 bullet, and evidence, changelog, and artifact SHA-256 close in a compact
 footer.
+
+## Publish and promote
+
+Include reviewed release notes in the releases directory, named for the tag with a .md suffix in the version
+PR. Its first line is `# YAML.sh vMAJOR.MINOR.PATCH — <quip>`; the remaining text
+is the release body described above. The publisher appends the built artifact's
+SHA-256. Keep claims about evidence tied to a real run.
+
+After the PR's Check passes and merges, create the signed tag on that main
+commit. Run the Release workflow on main with the tag. Pushing a tag alone does
+not publish. The workflow verifies main ancestry and GitHub's signature result,
+runs the checks, and verifies that the built version and checksum agree with the
+installer. It uploads `ysh` and `ysh.sha256` to a draft, downloads and compares
+them, then publishes. Re-run with the same tag to resume an incomplete draft;
+published releases are never overwritten.
+
+Site deployment verifies the installer's pinned download and checksum before
+shipping. A version PR can therefore merge before its artifact exists without
+publishing a broken installer: Deploy refuses until publication succeeds. The
+Release workflow then deploys current main through the same guarded task.
+Homebrew's daily YAML.sh updater verifies the published bytes and proposes the
+formula change; its manual workflow provides an immediate update when needed.

--- a/build/release-build.sh
+++ b/build/release-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+checksum() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$@"; else shasum -a 256 "$@"; fi; }
+tag=${1:?release-build: a tag is required}
+[[ "$tag" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]] || exit 1
+notes="releases/$tag.md"
+[ -s "$notes" ] || { echo "release-build: reviewed notes are missing at $notes" >&2; exit 1; }
+head -1 "$notes" | grep -Eq "^# YAML[.]sh $tag .+" || { echo 'release-build: notes need a release title and quip' >&2; exit 1; }
+make ysh
+[ "$(./ysh --version)" = "$tag" ] || { echo 'release-build: version differs from tag' >&2; exit 1; }
+sha=$(checksum ysh | cut -d' ' -f1)
+grep -Fxq "release_url=https://github.com/azohra/yaml.sh/releases/download/$tag/ysh" _static/_www/install
+grep -Fxq "expected_sha256=$sha" _static/_www/install
+rm -rf .release
+mkdir .release
+cp ysh .release/ysh
+printf '%s  ysh\n' "$sha" > .release/ysh.sha256
+sed '1d' "$notes" > .release/notes.md
+# shellcheck disable=SC2016
+printf '\n**Artifact SHA-256:** `%s`\n' "$sha" >> .release/notes.md
+head -1 "$notes" | sed 's/^# //' > .release/title.txt

--- a/build/release-consumer.sh
+++ b/build/release-consumer.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+checksum() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$@"; else shasum -a 256 "$@"; fi; }
+installer=_static/_www/install
+url=$(sed -n 's/^release_url=//p' "$installer")
+expected=$(sed -n 's/^expected_sha256=//p' "$installer")
+[[ "$url" =~ ^https://github.com/azohra/yaml[.]sh/releases/download/v[0-9]+[.][0-9]+[.][0-9]+/ysh$ ]] || exit 1
+[[ "$expected" =~ ^[0-9a-f]{64}$ ]] || exit 1
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+curl --fail --silent --show-error --location --retry 3 "$url" -o "$scratch/ysh"
+actual=$(checksum "$scratch/ysh" | cut -d' ' -f1)
+[ "$actual" = "$expected" ] || { echo 'release: installer does not match the published asset' >&2; exit 1; }
+echo 'Installer release asset and checksum verified'

--- a/build/release-publish.sh
+++ b/build/release-publish.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+checksum() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$@"; else shasum -a 256 "$@"; fi; }
+tag=${1:?release-publish: a tag is required}
+refuse() { echo "release: refusing — $*" >&2; exit 1; }
+[ "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" = azohra/yaml.sh ] || refuse 'unexpected repository'
+[ -z "$(git status --porcelain)" ] || refuse 'dirty tree'
+[ "$(bash build/release-source.sh "$tag")" = "$(git rev-parse HEAD)" ] || refuse 'tag is not HEAD'
+[ "$(.release/ysh --version)" = "$tag" ] || refuse 'artifact version differs from tag'
+(cd .release && checksum -c ysh.sha256)
+assets=(.release/ysh .release/ysh.sha256)
+existing_draft=""
+release_view_error=$(mktemp)
+if existing_draft=$(gh release view "$tag" --json isDraft --jq .isDraft 2>"$release_view_error"); then
+  rm -f "$release_view_error"
+  [ "$existing_draft" = "true" ] || refuse "release $tag is already published"
+else
+  if ! grep -Eiq 'not found|HTTP 404|status 404' "$release_view_error"; then
+    detail=$(tr '\n' ' ' <"$release_view_error")
+    rm -f "$release_view_error"
+    refuse "could not inspect release $tag${detail:+: $detail}"
+  fi
+  rm -f "$release_view_error"
+  gh release create "$tag" --draft --notes-file .release/notes.md --title "$(cat .release/title.txt)" --verify-tag
+fi
+gh release upload "$tag" "${assets[@]}" --clobber
+published_assets=$(gh release view "$tag" --json assets --jq '.assets[].name') || refuse "could not read uploaded assets"
+for asset in "${assets[@]}"; do
+  asset_name=${asset##*/}
+  grep -Fxq "$asset_name" <<<"$published_assets" || refuse "release is missing uploaded asset $asset_name"
+done
+download=$(mktemp -d)
+trap 'rm -rf "$download"' EXIT
+gh release download "$tag" --pattern ysh --pattern ysh.sha256 --dir "$download"
+cmp .release/ysh "$download/ysh"
+cmp .release/ysh.sha256 "$download/ysh.sha256"
+gh release edit "$tag" --draft=false
+published_state=$(gh release view "$tag" --json isDraft --jq .isDraft) || refuse "could not verify published release"
+[ "$published_state" = "false" ] || refuse "release $tag is still a draft"

--- a/build/release-source.sh
+++ b/build/release-source.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+tag=${1:?release-source: a tag is required}
+[[ "$tag" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)([.-][0-9A-Za-z.-]+)?$ ]] || { echo 'release-source: invalid release tag' >&2; exit 1; }
+git fetch -q origin main
+git fetch -q origin "refs/tags/$tag"
+sha=$(git rev-parse 'FETCH_HEAD^{commit}')
+git merge-base --is-ancestor "$sha" origin/main || { echo 'release-source: tag is outside origin/main' >&2; exit 1; }
+[ "$(git rev-parse "refs/tags/$tag")" = "$(git rev-parse FETCH_HEAD)" ] || { echo 'release-source: local and remote tags disagree' >&2; exit 1; }
+tag_object=$(git rev-parse "refs/tags/$tag")
+[ "$(git cat-file -t "$tag_object")" = tag ] || { echo 'release-source: an annotated signed tag is required' >&2; exit 1; }
+verified=$(gh api "repos/azohra/yaml.sh/git/tags/$tag_object" --jq '.verification.verified')
+[ "$verified" = true ] || { echo 'release-source: GitHub could not verify the tag signature' >&2; exit 1; }
+printf '%s\n' "$sha"

--- a/mise.toml
+++ b/mise.toml
@@ -242,9 +242,30 @@ set -euo pipefail
 git fetch -q origin main
 [ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ] || { echo "deploy: refusing — HEAD is not the tip of origin/main" >&2; exit 1; }
 mise run check
+mise run release:consumer
 if [ "${usage_dry_run:-false}" = "true" ]; then
   wrangler deploy --dry-run
   exit 0
 fi
 wrangler deploy --tag "$(git rev-parse --short HEAD)" --message "$(git log -1 --pretty=%s)"
 """
+
+[tasks."release:source"]
+description = "Resolve a signed release tag to its reviewed main commit"
+usage = 'arg "<tag>"'
+run = 'bash build/release-source.sh "$usage_tag"'
+
+[tasks."build:release"]
+description = "Build ysh and verify the version, installer checksum, and reviewed notes"
+depends = ["check"]
+usage = 'arg "<tag>"'
+run = 'bash build/release-build.sh "$usage_tag"'
+
+[tasks.release]
+description = "Upload, verify, and publish a draft release from built assets"
+usage = 'arg "<tag>"'
+run = 'bash build/release-publish.sh "$usage_tag"'
+
+[tasks."release:consumer"]
+description = "Verify the installer names an available release with matching bytes"
+run = 'bash build/release-consumer.sh'

--- a/test/release.sh
+++ b/test/release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+checksum() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$@"; else shasum -a 256 "$@"; fi; }
+root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/repo/_static/_www" "$scratch/repo/releases"
+cd "$scratch/repo"
+printf '#!/bin/sh\nprintf v1.2.3\n' > ysh
+chmod +x ysh
+printf 'ysh:; @true\n' > Makefile
+sha=$(checksum ysh | cut -d' ' -f1)
+printf 'release_url=https://github.com/azohra/yaml.sh/releases/download/v1.2.3/ysh\nexpected_sha256=%s\n' "$sha" > _static/_www/install
+printf '# YAML.sh v1.2.3 — example\n\nReviewed notes.\n' > releases/v1.2.3.md
+bash "$root/build/release-build.sh" v1.2.3
+(cd .release && checksum -c ysh.sha256)
+cmp ysh .release/ysh
+if bash "$root/build/release-build.sh" v1.2.4 >/dev/null 2>&1; then exit 1; fi
+printf 'bad checksum\n' >> ysh
+if bash "$root/build/release-build.sh" v1.2.3 >/dev/null 2>&1; then exit 1; fi
+# A corrupt or missing hosted artifact must stop deployment.
+mkdir "$scratch/bin"
+cat > "$scratch/bin/curl" <<'CURL'
+#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then shift; printf bad > "$1"; exit; fi
+  shift
+done
+exit 1
+CURL
+chmod +x "$scratch/bin/curl"
+if PATH="$scratch/bin:$PATH" bash "$root/build/release-consumer.sh" >/dev/null 2>&1; then exit 1; fi
+echo 'Release build and installer failure boundaries passed'


### PR DESCRIPTION
Add a manual Release workflow for signed tags on main. It verifies the tag, version, reviewed notes and installer checksum, builds the existing single-file distribution, and compares draft uploads before publishing. Deployment verifies the installer’s published download first; a successful release then deploys current main.

Validated with `mise run check`, release-build and corrupt-download fixtures, actionlint, the current signed tag, and its published installer bytes. No production release was created. Homebrew’s companion updater proposes formula changes from verified published assets; Bosun is seeded into a main-only release environment.
