### PR TITLE
Release YAML.sh 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to YAML.sh are documented here.
 
 ## Unreleased
 
+## [1.18.1] - 2026-09-05
+
+### Fixed
+
+- `has(-1)` on a sequence returns false instead of treating a negative index as an offset from the end.
+- Depth metadata is allocated only for collections, keeping scalar-heavy documents within the existing memory budget.
+- Node metadata is initialized explicitly, and clearing an anchor retains an empty scalar value for consistent behavior across AWK implementations.
+
 ### Changed
 
 - Documentation headings speak plainly: "Start with the job" became "Pick a task", "Know the boundary" became "What's supported — and what isn't", and the sidebar, page titles, and landing links now name reader tasks instead of internal design vocabulary.
@@ -543,6 +551,7 @@ Version 1 is a ground-up, intentionally breaking rebuild around a real YAML node
 
 - Report missing files and make the help flag exit successfully.
 
+[1.18.1]: https://github.com/azohra/yaml.sh/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/azohra/yaml.sh/compare/v1.17.1...v1.18.0
 [1.17.1]: https://github.com/azohra/yaml.sh/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/azohra/yaml.sh/compare/v1.16.0...v1.17.0

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,7 +30,7 @@ Releases come from tested `main` commits and use signed `vMAJOR.MINOR.PATCH` tag
 Bumping the version touches an exact set:
 
 1. `YSH_VERSION` in `src/ysh.sh`.
-2. The three version assertions in `test/test.sh`: `--version`, the installer download URL, and the homepage version marker.
+2. The version and installer checksum assertions in `test/test.sh`, plus the pinned installer URL in `test/docs.sh`.
 3. A dated `CHANGELOG.md` entry plus its compare-link definition at the file tail.
 4. Build the release artifact, calculate its SHA-256 digest, and pass that digest to
    `make docs RELEASE_SHA256=...`; this updates the installer checksum, homepage

--- a/_static/_www/docs/contracts/index.html
+++ b/_static/_www/docs/contracts/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="validate-patch-convert">Validate, patch &amp; convert</h1>
           <p>Validate a document, apply a standard patch, generate a reviewable change set, or convert configuration formats with the same <code>ysh</code> command.</p>

--- a/_static/_www/docs/development/index.html
+++ b/_static/_www/docs/development/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="development">Development</h1>
           <h2 id="build-everything"><a href="#build-everything">Build everything<span class="anchor-mark" aria-hidden="true">#</span></a></h2>

--- a/_static/_www/docs/documents/index.html
+++ b/_static/_www/docs/documents/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="editing-files-documents">Editing files &amp; documents</h1>
           <p>YAML.sh reads YAML streams, edits files without losing unrelated source text, and can prepare several file changes before writing any of them.</p>

--- a/_static/_www/docs/getting-started/index.html
+++ b/_static/_www/docs/getting-started/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="install-quick-start">Install &amp; quick start</h1>
           <p>YAML.sh ships as one executable text file containing its shell launcher and AWK engine.</p>

--- a/_static/_www/docs/index.html
+++ b/_static/_www/docs/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a aria-current="page" href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="yaml-in-shell-no-really">YAML in shell. No, really.</h1>
           <p>YAML.sh queries, transforms, validates, and edits YAML in one readable POSIX shell file with portable AWK inside. Common edits keep the comments and formatting around them.</p>

--- a/_static/_www/docs/internals/index.html
+++ b/_static/_www/docs/internals/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="parser-internals">Parser internals</h1>
           <p>The release remains one shell script, with a semantic graph, source-preservation layer, and batch file coordinator working together.</p>

--- a/_static/_www/docs/migration/index.html
+++ b/_static/_www/docs/migration/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="migrate-from-v0-x">Migrate from v0.x</h1>
           <p>Version 1 intentionally breaks the old CLI. v0.x transpiled YAML into a flat text representation, which prevented real structure, types, and comment-preserving edits.</p>

--- a/_static/_www/docs/operators/index.html
+++ b/_static/_www/docs/operators/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="operator-reference">Operator reference</h1>
           <p>This page is the compact index to YAML.sh's expression language. The <a href="/docs/queries/">query guide</a> explains each family with examples.</p>

--- a/_static/_www/docs/output/index.html
+++ b/_static/_www/docs/output/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="output-formats-inspection">Output formats &amp; inspection</h1>
           <p>The same query can return a value, JSON, YAML, TOML, INI, XML, a node type, its expanded tag, or its source line.</p>

--- a/_static/_www/docs/queries/index.html
+++ b/_static/_www/docs/queries/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="queries">Queries</h1>
           <p>YAML.sh expressions select values, pass them through filters, build new results, and update documents. An expression may produce no result, one result, or a stream of results.</p>

--- a/_static/_www/docs/recipes/index.html
+++ b/_static/_www/docs/recipes/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="recipes">Recipes</h1>
           <p>Start from the task. Every example uses the released <code>ysh</code> file and ordinary YAML input.</p>

--- a/_static/_www/docs/security/index.html
+++ b/_static/_www/docs/security/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="security-limits">Security &amp; limits</h1>
           <p>YAML.sh parses data and runs an explicit query program. YAML input is never evaluated as shell.</p>

--- a/_static/_www/docs/yaml-support/index.html
+++ b/_static/_www/docs/yaml-support/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="yaml-support">YAML support</h1>
           <p>YAML.sh accepts the syntax below. The parser boundaries section names nearby forms it rejects.</p>

--- a/_static/_www/docs/yq-compatibility/index.html
+++ b/_static/_www/docs/yq-compatibility/index.html
@@ -22,7 +22,7 @@
       <button class="header-search" type="button" data-search-open aria-label="Search documentation">Search</button>
       <a href="/docs/">Docs</a>
       <a href="https://github.com/azohra/yaml.sh">GitHub</a>
-      <a class="install" href="/docs/getting-started/">Install <span>v1.18.0</span></a>
+      <a class="install" href="/docs/getting-started/">Install <span>v1.18.1</span></a>
     </nav>
   </header>
   <details class="mobile-docs"><summary>Browse documentation</summary><nav>
@@ -103,7 +103,7 @@
       <p class="nav-foot">One file. <code>/bin/sh</code> + AWK.</p>
     </aside>
     <main id="content" class="doc-content">
-      <div class="breadcrumb"><span>Documentation</span><span>v1.18.0</span></div>
+      <div class="breadcrumb"><span>Documentation</span><span>v1.18.1</span></div>
       <article>
           <h1 id="coming-from-yq">Coming from yq</h1>
           <p>YAML.sh uses familiar yq-style paths, pipes, filters, construction, and assignment. Many everyday expressions transfer directly; YAML.sh is not a drop-in replacement for every yq program or CLI flag.</p>

--- a/_static/_www/index.html
+++ b/_static/_www/index.html
@@ -29,7 +29,7 @@
     <a class="brand" href="/" aria-label="YAML.sh home">
       <span class="brand-mark">Y</span>
       <span>YAML.sh</span>
-      <span class="version-pill" data-ysh-version>v1.18.0</span>
+      <span class="version-pill" data-ysh-version>v1.18.1</span>
     </a>
     <nav aria-label="Primary navigation">
       <a href="/story/">Story</a>
@@ -42,7 +42,7 @@
   <main id="main">
     <section class="hero section-shell">
       <div class="hero-copy">
-        <p class="eyebrow"><span class="status-dot"></span> Release <span data-ysh-version>v1.18.0</span> · one readable executable</p>
+        <p class="eyebrow"><span class="status-dot"></span> Release <span data-ysh-version>v1.18.1</span> · one readable executable</p>
         <h1>YAML in shell.<br><span>No, really.</span></h1>
         <p class="hero-lede">Query, transform, validate, and edit YAML with one portable <code>sh + awk</code> file. It has no business working this well.</p>
         <div class="hero-actions">
@@ -217,7 +217,7 @@ node  1  mapping  line=1</code></pre>
         <p>The installer downloads and checksum-verifies a pinned release, then places <code>ysh</code> in <code>/usr/local/bin</code>. Set <code>YSH_INSTALL_DIR</code> to choose another location.</p>
       </div>
       <div class="install-command">
-        <div class="install-command-label"><span>Terminal</span><span data-ysh-version>v1.18.0</span></div>
+        <div class="install-command-label"><span>Terminal</span><span data-ysh-version>v1.18.1</span></div>
         <pre><code id="install-code">curl -fsSL https://yaml.azohra.com/install | sh</code></pre>
         <button class="copy-button" type="button" data-copy="install-code"><span>Copy command</span><b aria-hidden="true">⌘</b></button>
         <p class="install-note">Homebrew: <code>brew install azohra/tools/ysh</code><br>Prefer to inspect first? <a href="/install">Read the installer source.</a></p>

--- a/_static/_www/install
+++ b/_static/_www/install
@@ -2,7 +2,7 @@
 set -eu
 
 install_dir=${YSH_INSTALL_DIR:-/usr/local/bin}
-release_url=https://github.com/azohra/yaml.sh/releases/download/v1.18.0/ysh
+release_url=https://github.com/azohra/yaml.sh/releases/download/v1.18.1/ysh
 release_version=${release_url##*/download/v}
 release_version=${release_version%/ysh}
 
@@ -19,7 +19,7 @@ fi
 temporary_file=$(mktemp "${TMPDIR:-/tmp}/ysh.XXXXXX")
 trap 'rm -f "${temporary_file}"' 0 HUP INT TERM
 
-expected_sha256=4ec74b5b1a5b96e5b60b5bcd3f44ad401e420a8b4662f54fc623fa9787f16dd3
+expected_sha256=2c486cc7ba37f94cd91694774ff88abd2fc21cafea7fd0ad962a5bd3941e8bcb
 curl -fsSL "${release_url}" -o "${temporary_file}"
 
 if command -v sha256sum >/dev/null 2>&1; then

--- a/mise.toml
+++ b/mise.toml
@@ -159,6 +159,7 @@ pin_file json-patch-spec-tests.json https://raw.githubusercontent.com/json-patch
 """
 
 [tasks.evidence]
+tools = { go = "1.27.1", jq = "1.8.1" }
 description = "Measure conformance, differential agreement, and the scale and benchmark budgets"
 depends = ["evidence:corpora"]
 run = """

--- a/releases/v1.18.1.md
+++ b/releases/v1.18.1.md
@@ -1,0 +1,15 @@
+# YAML.sh v1.18.1 — no negative surprises
+
+```console
+$ printf '[first, last]\n' | ysh 'has(-1)'
+false
+```
+
+- `has()` now treats negative sequence indexes as absent, instead of wrapping them around to the end.
+- Depth metadata is allocated only for collections, keeping scalar-heavy documents within the existing memory budget.
+- Explicit node metadata initialization keeps empty values and cleared anchors consistent across AWK implementations.
+- Documentation headings and navigation use the same task names across the site.
+
+The single-file POSIX shell and AWK runtime, installer URL, and Homebrew command stay the same.
+
+Validation covers runtime and documentation checks, Linux and macOS portability, and the pinned conformance and differential suites. [Changelog](https://github.com/azohra/yaml.sh/blob/v1.18.1/CHANGELOG.md).

--- a/src/awk/21-graph.awk
+++ b/src/awk/21-graph.awk
@@ -9,7 +9,9 @@ function new_node(kind, source_line, value, value_type, tag,    node) {
     node_type[node] = value_type
     node_tag[node] = tag
     node_anchor[node] = ""
-    node_depth[node] = 0
+    if (kind == "mapping" || kind == "sequence" || kind == "pending") {
+        node_depth[node] = 0
+    }
     node_style[node] = ""
     if (document_index != file_document_offset) {
         node_document[node] = document_index - file_document_offset

--- a/src/ysh.sh
+++ b/src/ysh.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.18.0
+YSH_VERSION=1.18.1
 
 # Replaced by the build with the embedded AWK engine.
 # YSH_AWK_PROGRAM

--- a/test/docs.sh
+++ b/test/docs.sh
@@ -41,7 +41,7 @@ if ! awk -v version=9.9.9 -f "$ROOT/build/docbuilder.awk" "$ROOT/_static/_www/in
     printf '%s\n' 'Ordinary documentation builds rewrite the pinned release checksum.' >&2
     exit 1
 fi
-if ! awk -f "$ROOT/build/docbuilder.awk" "$ROOT/_static/_www/install" | grep -Fq 'releases/download/v1.18.0/ysh'; then
+if ! awk -f "$ROOT/build/docbuilder.awk" "$ROOT/_static/_www/install" | grep -Fq 'releases/download/v1.18.1/ysh'; then
     printf '%s\n' 'Ordinary documentation builds rewrite the pinned release URL.' >&2
     exit 1
 fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,7 +19,7 @@ assertYshFails() {
 }
 
 testVersion() {
-    assertEquals "v1.18.0" "$(./ysh --version)"
+    assertEquals "v1.18.1" "$(./ysh --version)"
 }
 
 testHelp() {
@@ -1690,10 +1690,10 @@ testRunsWithPosixShell() {
 }
 
 testReleaseArtifactsStayInSync() {
-    assertContains "$(cat _static/_www/install)" "v1.18.0/ysh"
-    assertContains "$(cat _static/_www/install)" "expected_sha256=4ec74b5b1a5b96e5b60b5bcd3f44ad401e420a8b4662f54fc623fa9787f16dd3"
+    assertContains "$(cat _static/_www/install)" "v1.18.1/ysh"
+    assertContains "$(cat _static/_www/install)" "expected_sha256=2c486cc7ba37f94cd91694774ff88abd2fc21cafea7fd0ad962a5bd3941e8bcb"
     assertContains "$(cat _static/_www/install)" "checksum verification failed"
-    assertContains "$(cat _static/_www/index.html)" "data-ysh-version>v1.18.0"
+    assertContains "$(cat _static/_www/index.html)" "data-ysh-version>v1.18.1"
     assertTrue "evergreen social preview image must exist" "[ -s _static/_www/og.png ]"
 }
 

--- a/ysh
+++ b/ysh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-YSH_VERSION=1.18.0
+YSH_VERSION=1.18.1
 
 # Replaced by the build with the embedded AWK engine.
 ysh_awk_program() {
@@ -2293,7 +2293,9 @@ function new_node(kind, source_line, value, value_type, tag,    node) {
     node_type[node] = value_type
     node_tag[node] = tag
     node_anchor[node] = ""
-    node_depth[node] = 0
+    if (kind == "mapping" || kind == "sequence" || kind == "pending") {
+        node_depth[node] = 0
+    }
     node_style[node] = ""
     if (document_index != file_document_offset) {
         node_document[node] = document_index - file_document_offset


### PR DESCRIPTION
Release the merged negative-index and AWK portability fixes as v1.18.1, with matching installer bytes, site metadata and reviewed release notes. Allocate depth metadata only for collections so the portability fix stays within the existing 224 MiB scale limit.

Declare the Go and jq tools used by release evidence, and include the pinned docs-test URL in the versioning checklist.

Validation: `mise run check`, `mise run evidence`, `mise run evidence:busybox`, `mise run check:linux-portability` and `mise run build:release -- v1.18.1`. The scale test processes 125,000 nodes within the unchanged memory and time limits.
