### PR TITLE
ci: enforce Conventional PR titles

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,0 +1,37 @@
+name: Conventional PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - if: github.event_name == 'pull_request_target'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+      - if: github.event_name == 'push'
+        run: ":"


### PR DESCRIPTION
Pull request titles are now validated from trusted `main` before merge. The workflow checks out no pull request code and has read-only pull-request access, so contributors cannot replace the validator that judges their title.
