### PR TITLE
fix: link changelog entries to their pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -28,7 +29,7 @@ jobs:
           MISE_GITHUB_TOKEN: ${{ github.token }}
       - name: Publish release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: mise run release
 
   deploy:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,6 +43,10 @@ This renders recorded changes and releases from Git, followed by the historical
 entries in `CHANGELOG.md`. New entries use the reviewed title and link to the
 full commit. Breaking-change notes retain migration instructions. Published
 release notes are available in [GitHub Releases](https://github.com/azohra/yaml.sh/releases).
+Changelog rendering uses GitHub PR metadata for links, with commit links when no
+associated PR is available. Set `GITHUB_TOKEN` for authenticated GitHub access;
+version calculation remains offline.
+
 Versions and notes are calculated without rewriting source or opening a version PR.
 
 ## Publish the executable

--- a/cliff.toml
+++ b/cliff.toml
@@ -7,7 +7,11 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
 {% for commit in commits %}
-- {% if commit.breaking %}**Breaking:** {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/azohra/yaml.sh/commit/{{ commit.id }}))
+{%- set message = commit.message %}
+{%- if commit.remote.pr_number %}
+{%- set message = message | trim_end_matches(pat=" (#" ~ commit.remote.pr_number ~ ")") %}
+{%- endif %}
+- {% if commit.breaking %}**Breaking:** {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ message }} {% if commit.remote.pr_number %}([#{{ commit.remote.pr_number }}](https://github.com/azohra/yaml.sh/pull/{{ commit.remote.pr_number }})){% else %}([{{ commit.id | truncate(length=7, end="") }}](https://github.com/azohra/yaml.sh/commit/{{ commit.id }})){% endif %}
 {% if commit.breaking_description %}
   **Breaking change:** {{ commit.breaking_description | indent(prefix="  ", first=false) }}
 {% endif %}{% endfor %}{% endfor %}
@@ -32,3 +36,7 @@ commit_parsers = [
   { message = '^docs', group = "Documentation" },
   { message = '.*', group = "Other changes" },
 ]
+
+[remote.github]
+owner = "azohra"
+repo = "yaml.sh"

--- a/mise.toml
+++ b/mise.toml
@@ -235,7 +235,7 @@ run = '''
 set -euo pipefail
 archive=$(sed -n 's/^## \[\([0-9.]*\)\].*/\1/p' CHANGELOG.md | head -n 1)
 printf '# Changelog\n\n'
-git cliff --offline "v$archive..HEAD"
+git cliff "v$archive..HEAD"
 printf '\n'
 awk '/^## \[/{history=1} history' CHANGELOG.md
 '''
@@ -257,7 +257,7 @@ make .release/ysh RELEASE_VERSION="${tag#v}"
 [ "$(sh .release/ysh --version)" = "$tag" ]
 [ "$(printf 'answer: 42\n' | sh .release/ysh '.answer')" = 42 ]
 (cd .release && shasum -a 256 ysh > ysh.sha256)
-git cliff --offline --unreleased --tag "$tag" > .release/notes.md
+git cliff --unreleased --tag "$tag" > .release/notes.md
 gh release create "$tag" .release/ysh .release/ysh.sha256 \
   --repo azohra/yaml.sh --target "$head" \
   --title "YAML.sh $tag" --notes-file .release/notes.md


### PR DESCRIPTION
Changelog entries now link to their originating pull requests using git-cliff’s native GitHub metadata. Commits without an associated PR retain their commit links, and an existing PR-number suffix is omitted when the same PR is linked explicitly.

Enable GitHub metadata for changelog and release-note rendering while keeping version calculation offline. The Release workflow supplies its existing repository token to both git-cliff and GitHub CLI, with read access to pull requests.
