### PR TITLE
build: align pre-v1 breaking-change versioning

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,3 +1,6 @@
+[bump]
+breaking_always_bump_major = false
+
 [changelog]
 header = ""
 body = """


### PR DESCRIPTION
Use git-cliff's native pre-v1 setting so breaking changes increment the minor version while the major version is zero. Breaking changes after v1 continue to increment the major version.
