### PR TITLE
build(changelog): follow the maintained shared preset

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -49,7 +49,7 @@ release notes are available in [GitHub Releases](https://github.com/azohra/yaml.
 Changelog rendering uses GitHub PR metadata for links, with commit links when no
 associated PR is available. Set `GITHUB_TOKEN` for authenticated GitHub access;
 the preset itself is downloaded for every invocation, including version calculation.
-Its URL in `mise.toml` pins the shared configuration to a reviewed commit.
+Its URL in `mise.toml` follows the shared configuration on main.
 
 `mise run changelog -- --json` exports git-cliff's structured context, including
 bodies, footers and available GitHub metadata. It covers Git history only; it

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@
 experimental = true
 
 [vars]
-changelog_config = "https://raw.githubusercontent.com/azohra/conventional-pr/00ed923287317e0726db1d0b1f6edf8420caa6c2/cliff.toml"
+changelog_config = "https://raw.githubusercontent.com/azohra/conventional-pr/main/cliff.toml"
 
 [env]
 # Where the pinned corpora live. Gitignored: fetched, never committed.


### PR DESCRIPTION
## Summary

Adopt shared changelog updates directly from Conventional PR main, including the Summary/Details presentation. Future changelog rendering and version calculations use the maintained preset without per-repository SHA updates. Published release notes remain unchanged.

## Details

The preset includes version rules as well as formatting. Executable GitHub Actions remain pinned to reviewed commits.
