### PR TITLE
ci: share the fleet's title check and give Dependabot Conventional titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       github-actions-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    commit-message:
+      prefix: ci
+      include: scope
   - package-ecosystem: "docker"
     directory: "/test"
     schedule:
@@ -28,3 +31,6 @@ updates:
       docker-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    commit-message:
+      prefix: fix
+      include: scope

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -4,7 +4,8 @@ on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   title:
@@ -12,4 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: azohra/conventional-pr@c86109511263ca80e66a2fb8500182c2890dc121
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false


### PR DESCRIPTION
Validate PR titles with the pinned `amannn/action-semantic-pull-request` the rest of the fleet uses, keeping the job name so the required check in the ruleset is untouched. `azohra/conventional-pr` is being retired; its only value was the shared changelog config, which now lives in a gist.

Dependabot titles are Conventional too: `ci(deps)` for GitHub Actions, `fix(deps)` for dependencies that ship, `build(deps-dev)` for npm development dependencies. Its untitled "Bump X" PRs were failing the required check before anyone read them.
