### PR TITLE
build: release ysh only when it changes and deploy the website on every merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release and deploy
 
 on:
   push:
@@ -27,14 +27,14 @@ jobs:
           MISE_GITHUB_TOKEN: ${{ github.token }}
         with:
           minimum_release_age: 24h
-      - name: Release
+      - name: Release when ysh changed
         id: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           tag=$(mise run --quiet release)
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-      - name: Deploy
+      - name: Deploy the website
         env:
           GH_TOKEN: ${{ github.token }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Edit the sources and run their build command:
 | --- | --- |
 | `ysh` (ignored) | `src/ysh.sh`, `src/awk/*.awk`, and `src/diff.awk`; `make ysh` builds the development executable |
 | `.release/site/docs/` | `mise run build` renders the documentation Markdown; these outputs are not committed |
-| `.release/` (ignored) | `mise run release` builds and publishes the versioned executable, checksum, website archive and release notes |
+| `.release/` (ignored) | Build output: the versioned executable, its checksum and the generated website |
 | `.release/site/` (ignored) | `mise run build [tag]` builds the executable and website together, including the deployable archive |
 
 The PR title and body become the squash commit and supply the changelog.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -25,13 +25,14 @@ Undocumented internals and rejected malformed or unsupported input are outside t
 
 ## Changes and validation
 
-The reviewed PR title and body become the squash commit. Its Conventional title
-sets aggregate impact using git-cliff's default bump rules: a breaking header or
-`BREAKING CHANGE:` footer produces a major, `feat` produces a minor, and other
-Conventional changes produce patches. Non-Conventional commits are excluded.
-Nested Conventional headings in the body are ordinary prose. The
-[Conventional PR format](https://github.com/azohra/conventional-pr#bodies-and-annotations)
-defines the validated message and optional annotations.
+The reviewed PR title and body become the squash commit. A version is cut only
+when the assembled `ysh` differs from the published release; documentation,
+website and tooling merges deploy the website and do not release. When it does
+differ, the Conventional titles since the last release choose the number with
+git-cliff's rules: a breaking header or `BREAKING CHANGE:` footer produces a
+major, `feat` a minor, `fix` a patch. `build`, `chore`, `ci`, `docs`, `style`
+and `test` never move the version, so a change to the program needs a `feat`
+or `fix` title.
 
 PR checks build and test the proposed merge. Main requires passing checks against
 the current base before merging. The full suite runs before merge; publication
@@ -43,13 +44,11 @@ mise run changelog
 
 This renders recorded changes and releases from Git, followed by the historical
 entries in `CHANGELOG.md`. Each entry shows the reviewed title and PR link, with
-migration instructions and footers visible. Expand **Details** for the full
-explanation, including Markdown lists and code examples. Published
-release notes are available in [GitHub Releases](https://github.com/azohra/yaml.sh/releases).
+the body, migration instructions and footers visible. Published release notes are available in [GitHub Releases](https://github.com/azohra/yaml.sh/releases).
 Changelog rendering uses GitHub PR metadata for links, with commit links when no
 associated PR is available. Set `GITHUB_TOKEN` for authenticated GitHub access;
-the preset itself is downloaded for every invocation, including version calculation.
-Its URL in `mise.toml` follows the shared configuration on main.
+the shared git-cliff config named in `mise.toml` is downloaded for every
+invocation, including version calculation.
 
 `mise run changelog -- --json` exports git-cliff's structured context, including
 bodies, footers and available GitHub metadata. It covers Git history only; it
@@ -60,39 +59,25 @@ Versions and notes are calculated without rewriting source or opening a version 
 
 ## Build, release and deploy
 
-`mise run build [tag]` produces the executable, its checksum and the deployable
-website archive in `.release/`. Without a tag, it builds `vdev` for local checks.
-The executable is smoke-tested, documentation is generated from Markdown, and
-the installer and homepage use that executable's version. Generated pages are
-build output and are not committed.
+`mise run build [tag]` produces the executable and its checksum in `.release/`
+and the website in `.release/site`. Without a tag it builds `vdev` for local
+checks. The executable is smoke-tested, documentation is generated from
+Markdown, and the installer and homepage use that executable's version.
+Generated output is not committed.
 
-Each merge to main queues a release of that commit, followed by website
-deployment. Git-cliff calculates the version once; the build receives it and
-the release notes use it. PR checks exercise the same build with a development
-version, including the generated site's links and deployment configuration.
+Every merge to main runs the Release and deploy workflow. `mise run release`
+builds `ysh` as the published version and compares checksums. Unchanged: it
+prints the current tag and stops. Changed: it computes the next version, builds
+it, publishes the release with `ysh`, `ysh.sha256` and generated notes, and
+prints the new tag. An interrupted draft upload can be retried from the same
+source; a draft belonging to different source is refused.
 
-`mise run release` publishes the checked-out main commit and prints its tag.
-The release contains `ysh`, `ysh.sha256` and `site.tar.gz`. The archive contains
-the generated website and its Wrangler configuration. No source version file
-or generated changelog commit is required.
+`mise run deploy <tag>` builds the website from the checkout for that published
+release and deploys it to Cloudflare, tagged with the version and commit. The
+installer on the site therefore always points at the latest published `ysh`,
+and documentation changes go live on merge. Cloudflare keeps every deployed
+version; to restore an earlier one, use `wrangler rollback` or check out the
+commit and deploy again.
 
-An interrupted draft upload can be retried with `mise run release` from the
-same source: it rebuilds that version and replaces only draft assets before
-publishing. A draft belonging to different source is refused. Once published,
-repeating release returns its tag without rebuilding or replacing assets.
-Local publication should not run alongside the workflow. New releases from
-source older than an existing descendant release are refused.
-
-```sh
-mise run deploy <release-tag> --dry-run
-mise run deploy <release-tag>
-```
-
-Deployment downloads and extracts the published archive and uses its Wrangler
-configuration. It does not use the checkout's website files or rebuild the
-product. The same command retries deployment or restores an earlier release,
-without switching branches. Releases created before the website archive was
-introduced do not contain this deployable bundle.
-
-A failed deployment leaves the published release available. Homebrew's updater
-follows the published executable and checksum independently of website deployment.
+Homebrew's updater follows the published executable and checksum independently
+of website deployment.

--- a/build/site.sh
+++ b/build/site.sh
@@ -16,4 +16,3 @@ YSH_DOCS_OUTPUT="$PWD/.release/site/docs" ./build/docs.sh
 find .release/site -name '*.md' -delete
 awk -v version="${tag#v}" -v sha256="$sha" -f build/docbuilder.awk _static/_www/install > .release/site/install
 awk -v version="${tag#v}" -f build/docbuilder.awk _static/_www/index.html > .release/site/index.html
-tar -czf .release/site.tar.gz wrangler.jsonc .release/site

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@
 experimental = true
 
 [vars]
-changelog_config = "https://raw.githubusercontent.com/azohra/conventional-pr/main/cliff.toml"
+changelog_config = "https://gist.githubusercontent.com/azohra/2bf7f60736469fa8a81ffcb67214e572/raw/cliff.toml"
 
 [env]
 # Where the pinned corpora live. Gitignored: fetched, never committed.
@@ -247,25 +247,35 @@ awk '/^## \[/{history=1} history' CHANGELOG.md
 '''
 
 [tasks.release]
-description = "Build and publish the checked-out main commit; print its tag"
+description = "Publish ysh when the assembled program changed; print the current tag either way"
 tools = { gh = "2.100.0" }
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
-[ -z "$(git status --porcelain)" ] || { echo 'Commit changes first' >&2; exit 1; }
+[ -z "$(git status --porcelain)" ] || { echo 'release: commit changes first' >&2; exit 1; }
 git fetch -q origin main --tags
 head=$(git rev-parse HEAD)
-git merge-base --is-ancestor "$head" origin/main || { echo 'Check out a merged main commit' >&2; exit 1; }
-tag=$(git tag --points-at HEAD --list 'v[0-9]*')
-if [ -n "$tag" ]; then
-  [ "$(gh release view "$tag" --json isDraft --jq .isDraft)" = false ] || exit 1
-  printf '%s\n' "$tag"
+git merge-base --is-ancestor "$head" origin/main || { echo 'release: check out a merged main commit' >&2; exit 1; }
+digest() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1; else shasum -a 256 "$1" | cut -d' ' -f1; fi; }
+
+# A version names a change to the program. Build ysh as the published version
+# and compare bytes; docs, site and tooling merges leave it identical.
+current=$(gh release view --json tagName --jq .tagName)
+[[ "$current" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]] || { echo "release: no published release to compare against" >&2; exit 1; }
+make .release/ysh RELEASE_VERSION="${current#v}" >/dev/null
+published=$(gh release download "$current" --pattern ysh.sha256 --output - | cut -d' ' -f1)
+if [ "$(digest .release/ysh)" = "$published" ]; then
+  echo "ysh is unchanged since $current; nothing to release" >&2
+  printf '%s
+' "$current"
   exit 0
 fi
-[ -z "$(git tag --contains HEAD --list 'v[0-9]*')" ] || { echo 'A newer release exists; deploy a published tag explicitly' >&2; exit 1; }
+
 tag=$(git cliff --config-url "{{vars.changelog_config}}" --offline --unreleased --bumped-version)
+[[ "$tag" =~ ^v[0-9]+[.][0-9]+[.][0-9]+$ ]] || { echo "release: could not compute a version" >&2; exit 1; }
+[ "$tag" != "$current" ] || { echo "release: ysh changed since $current but no feat or fix commit moves the version" >&2; exit 1; }
 if git show-ref --verify --quiet "refs/tags/$tag"; then
-  echo "Tag $tag already exists; inspect its release" >&2
+  echo "release: tag $tag already exists; inspect its release" >&2
   exit 1
 fi
 mise run build -- "$tag" >&2
@@ -273,14 +283,15 @@ git cliff --config-url "{{vars.changelog_config}}" --unreleased --tag "$tag" > .
 if ! gh release view "$tag" >/dev/null 2>&1; then
   gh release create "$tag" --draft --target "$head" --title "YAML.sh $tag" --notes-file .release/notes.md >&2
 fi
-[ "$(gh release view "$tag" --json isDraft,targetCommitish --jq ".isDraft and .targetCommitish == \"$head\"")" = true ] || { echo 'Release belongs to different source or is already published' >&2; exit 1; }
-gh release upload "$tag" .release/ysh .release/ysh.sha256 .release/site.tar.gz --clobber >&2
+[ "$(gh release view "$tag" --json isDraft,targetCommitish --jq ".isDraft and .targetCommitish == \"$head\"")" = true ] || { echo 'release: the draft belongs to different source or is already published' >&2; exit 1; }
+gh release upload "$tag" .release/ysh .release/ysh.sha256 --clobber >&2
 gh release edit "$tag" --draft=false >&2
-printf '%s\n' "$tag"
+printf '%s
+' "$tag"
 '''
 
 [tasks.build]
-description = "Build the executable and deployable website"
+description = "Build the executable and the website"
 usage = 'arg "[tag]" default="vdev"'
 run = '''
 #!/usr/bin/env bash
@@ -292,20 +303,14 @@ make build RELEASE_VERSION="${tag#v}"
 '''
 
 [tasks.deploy]
-description = "Deploy a published website archive"
+description = "Build the website for a published release and deploy it"
 tools = { gh = "2.100.0" }
-usage = '''arg "<tag>"
-flag "--dry-run" help="Validate without deploying"'''
+usage = 'arg "<tag>"'
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
 tag=${usage_tag:?}
-[ "$(gh release view "$tag" --json isDraft,isPrerelease --jq '(.isDraft or .isPrerelease) | not')" = true ] || exit 1
-scratch=$(mktemp -d)
-trap 'rm -rf "$scratch"' EXIT
-gh release download "$tag" --pattern site.tar.gz --dir "$scratch"
-tar -xzf "$scratch/site.tar.gz" -C "$scratch"
-args=()
-if [ "${usage_dry_run:-false}" = true ]; then args+=(--dry-run); fi
-wrangler deploy --config "$scratch/wrangler.jsonc" --tag "$tag" "${args[@]}"
+[ "$(gh release view "$tag" --json isDraft,isPrerelease --jq '(.isDraft or .isPrerelease) | not')" = true ] || { echo "deploy: $tag is not a published release" >&2; exit 1; }
+mise run build -- "$tag" >&2
+wrangler deploy --tag "$tag-$(git rev-parse --short HEAD)"
 '''


### PR DESCRIPTION
Every merge cut a release, and the website only deployed as part of one. The version had stopped meaning anything: `ysh` built from main today is byte-identical to the v1.18.1 release, and three releases followed it anyway. Under the shared git-cliff config, which skips docs and tooling, a documentation merge would never have deployed the site.

A release now happens only when the assembled `ysh` differs from the published one. `mise run release` builds it as the current version and compares checksums; unchanged, it prints the current tag and stops. Changed, it computes the next version from the Conventional titles, publishes `ysh` and `ysh.sha256` with generated notes, and prints the new tag. A changed program with no `feat` or `fix` title fails the step instead of shipping under the old number.

The website deploys on every merge. `mise run deploy <tag>` builds the site from the checkout for that published release and deploys it, so the installer always points at the latest published `ysh` and documentation goes live on merge. The `site.tar.gz` asset is gone. The shared changelog config moves to its gist, and VERSIONING.md describes the rule.
